### PR TITLE
Upgrade Testcontainers 1.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
-version = 0.4.1
+version = 0.5.0
 
 archivesBaseName = "testcontainers-scala"
 
-testcontainersVersion = 1.1.8
+testcontainersVersion = 1.2.0
 scalaVersion = 2.12.1
 seleniumVersion = 2.53.0
 slf4jVersion = 1.7.21


### PR DESCRIPTION
Upgraded testcontainers version and bumped minor version.

Note: when testing with the most recent version of docker for mac [this bug](https://github.com/testcontainers/testcontainers-java/issues/293) cause by [this other bug](https://github.com/docker-java/docker-java/issues/806) prevented testcontainers from working correctly. After manually pulling the images and then commenting out `~/.docker/config.json` would testcontainers and the tests work. Once docker-java gets fixed this workaround won't be needed anymore.

Fixes #2 