### PR TITLE
Don't start container when all tests are ignored

### DIFF
--- a/src/main/scala/com/dimafeng/testcontainers/TestContainer.scala
+++ b/src/main/scala/com/dimafeng/testcontainers/TestContainer.scala
@@ -59,16 +59,20 @@ trait ForAllTestContainer extends SuiteMixin {
   implicit private val suiteDescription = Description.createSuiteDescription(self.getClass)
 
   abstract override def run(testName: Option[String], args: Args): Status = {
-    container.starting()
-    afterStart()
-    try {
-      super.run(testName, args)
-    } finally {
+    if (expectedTestCount(args.filter) == 0) {
+      new CompositeStatus(Set.empty)
+    } else {
+      container.starting()
+      afterStart()
       try {
-        beforeStop()
-      }
-      finally {
-        container.finished()
+        super.run(testName, args)
+      } finally {
+        try {
+          beforeStop()
+        }
+        finally {
+          container.finished()
+        }
       }
     }
   }


### PR DESCRIPTION
We wanted to ignore integration tests, but noticed that docker containers are still started, even though all tests have been ignored.

This patch fixes the `ForAllTestContainer` trait to not start containers in the case that all tests are ignored

### 24 Pull Requests (https://24pullrequests.com) ###
![https://24pullrequests.com](https://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png
)