### PR TITLE
Removed shapeless and make LazyContainer required for MultipleContainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,25 +226,23 @@ class PostgresqlSpec extends FlatSpec with ForAllTestContainer  {
 
 ### Multiple Containers
 
+If you need to test more than one container in your test, you could use `MultipleContainers` for that. Just define your containers and pass them to the `MultipleContainers` constructor:
 ```scala
-...
-val container = MultipleContainers(MySQLContainer(), GenericContainer(...))
+val mySqlContainer = MySQLContainer()
+val genericContainer = GenericContainer(...)
 
-// access to containers
-containers.containers._1.containerId // container id of the first container
-...
-
+override val container = MultipleContainers(mySqlContainer, genericContainer)
 ```
 
 #### Dependent containers
 
-If configuration of one container depends on runtime state of another one, you can use `LazyContainer` wrapper as follows:
+If configuration of one container depends on runtime state of another one, you should define your containers as `lazy`:
 
 ```scala
 lazy val container1 = Container1()
 lazy val container2 = Container2(container1.port)
 
-val containers = MultipleContainers(LazyContainer(pgContainer), LazyContainer(appContainer))
+override val containers = MultipleContainers(pgContainer, appContainer)
 ```
 
 ### Fixed Host Port Containers
@@ -281,6 +279,11 @@ class MysqlSpec extends FlatSpec with ForAllTestContainer {
 
 ## Release notes
 
+* **0.17.0**
+    * Removed `shapeless` dependency
+    * Added implicit conversion to `LazyContainer`. This gives you a possibility to not wrap your containers into the `LazyContainer` manually.
+    * `MultipleContainers.apply` now receives `LazyContainer[_]*` type. Together with the previous point, it makes usage experience of `MultipleContainers` more smooth.
+
 * **0.16.0**
     * `FixedHostPortGenericContainer` added
 
@@ -313,7 +316,7 @@ class MysqlSpec extends FlatSpec with ForAllTestContainer {
 
 * **0.6.0**
     * TestContainers `1.2.0` -> `1.2.1`
-    * Fix of the `afterStart` hook 
+    * Fix of the `afterStart` hook
 
 * **0.5.0**
     * TestContainers `1.1.8` -> `1.2.0`
@@ -324,7 +327,7 @@ class MysqlSpec extends FlatSpec with ForAllTestContainer {
 * **0.4.0**
     * TestContainers `1.1.5` -> `1.1.7`
     * Scala cross-building (2.11.* + 2.12.*)
-    
+
 * **0.3.0**
     * TestContainers `1.1.0` -> `1.1.5`
     * Start/Stop hooks

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,6 @@ val scalaTestVersion = "3.0.1"
 val mysqlConnectorVersion = "5.1.39"
 val postgresqlDriverVersion = "9.4.1212"
 val mockitoVersion = "1.10.19"
-val shapelessVersion = "2.3.3"
 
 lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")
 
@@ -27,8 +26,7 @@ lazy val root = (project in file("."))
       */
     libraryDependencies ++=
       COMPILE(
-        "org.testcontainers" % "testcontainers" % testcontainersVersion,
-        "com.chuusai" %% "shapeless" % shapelessVersion
+        "org.testcontainers" % "testcontainers" % testcontainersVersion
       )
         ++ PROVIDED(
         "org.seleniumhq.selenium" % "selenium-java" % seleniumVersion,

--- a/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala
+++ b/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala
@@ -1,48 +1,51 @@
 package com.dimafeng.testcontainers
 
 import org.junit.runner.Description
-import shapeless._
-import shapeless.ops.hlist._
 
-class MultipleContainers[H <: HList] private(val containers: H)(implicit ev: ToTraversable.Aux[H, List, Any]) extends Container {
+import scala.language.implicitConversions
 
-  private lazy val containersAsIterator = containers.toList.map(_.asInstanceOf[Container])
+class MultipleContainers private(containers: Seq[LazyContainer[_]]) extends Container {
 
-  override def finished()(implicit description: Description): Unit = containersAsIterator.foreach(_.finished()(description))
+  override def finished()(implicit description: Description): Unit = containers.foreach(_.finished()(description))
 
-  override def succeeded()(implicit description: Description): Unit = containersAsIterator.foreach(_.succeeded()(description))
+  override def succeeded()(implicit description: Description): Unit = containers.foreach(_.succeeded()(description))
 
-  override def starting()(implicit description: Description): Unit = containersAsIterator.foreach(_.starting()(description))
+  override def starting()(implicit description: Description): Unit = containers.foreach(_.starting()(description))
 
-  override def failed(e: Throwable)(implicit description: Description): Unit = containersAsIterator.foreach(_.failed(e)(description))
+  override def failed(e: Throwable)(implicit description: Description): Unit = containers.foreach(_.failed(e)(description))
 }
 
 object MultipleContainers {
 
-  import shapeless.Generic
-
   /**
     * Creates a `MultipleContainers` instance with nested containers (support 2+ nested containers)
     *  {{{
-    *  val containers = MultipleContainers(PostgreSQLContainer(), MySQLContainer(), SeleniumContainer())
+    *  val pgContainer = PostgreSQLContainer()
+    *  val mySqlContainer = MySQLContainer()
+    *  val seleniumContainer = SeleniumContainer()
+    *
+    *  val containers = MultipleContainers(pgContainer, mySqlContainer, seleniumContainer)
     *  }}}
     *
-    *  Allows container dependencies using `LazyContainer`
+    * In case of dependent containers you need to define this containers explicitly with `lazy val`,
+    * and after that pass them to the `MultipleContainers`:
     *  {{{
-    *      lazy val pgContainer = PostgreSQLContainer()
-    *      lazy val appContainer = AppContainer(pgContainer.jdbcUrl, pgContainer.username, pgContainer.password)
+    *  lazy val pgContainer = PostgreSQLContainer()
+    *  lazy val appContainer = AppContainer(pgContainer.jdbcUrl, pgContainer.username, pgContainer.password)
     *
-    *      val containers = MultipleContainers(LazyContainer(pgContainer), LazyContainer(appContainer))
+    *  val containers = MultipleContainers(pgContainer, appContainer)
     *  }}}
     */
-  def apply[P <: Product, L <: HList](p: P)(implicit gen: Generic.Aux[P, L], ev: ToTraversable.Aux[L, List, Any]): MultipleContainers[L] =
-    new MultipleContainers[L](gen.to(p))
+  def apply(containers: LazyContainer[_]*): MultipleContainers = new MultipleContainers(containers)
 }
 
 /**
   * Lazy container wrapper aims to solve the problem of cross-container dependencies in `MultipleContainers` when a second container
   * requires some after start data from a first one (e.g. an application container needs JDBC url of a container with a database - in that case
   * the url becomes available after the database container has started)
+  *
+  * You don't need to wrap your containers into the `LazyContainer` manually
+  * when you pass your containers in the `MultipleContainers`- there is implicit conversion for that.
   */
 class LazyContainer[T <: Container](factory: => T) extends Container {
   lazy val container: T = factory
@@ -57,5 +60,8 @@ class LazyContainer[T <: Container](factory: => T) extends Container {
 }
 
 object LazyContainer {
+
+  implicit def containerToLazyContainer[T <: Container](container: => T): LazyContainer[T] = LazyContainer(container)
+
   def apply[T <: Container](factory: => T): LazyContainer[T] = new LazyContainer(factory)
 }

--- a/src/test/scala/com/dimafeng/testcontainers/MultipleContainersSpec.scala
+++ b/src/test/scala/com/dimafeng/testcontainers/MultipleContainersSpec.scala
@@ -36,7 +36,7 @@ class MultipleContainersSpec extends BaseSpec[ForEachTestContainer] {
     lazy val container1 = new InitializableContainer("after start value")
     lazy val container2 = new InitializableContainer(container1.value)
 
-    val containers = MultipleContainers(LazyContainer(container1), LazyContainer(container2))
+    val containers = MultipleContainers(container1, container2)
 
     new TestSpec({
       assert(1 == 1)
@@ -44,34 +44,6 @@ class MultipleContainersSpec extends BaseSpec[ForEachTestContainer] {
 
     assert(container1.value == "after start value")
     assert(container2.value == "after start value")
-  }
-
-  it should "not initialize containers lazily if they are not defined as lazy" in {
-    lazy val container1 = new InitializableContainer("after start value")
-    lazy val container2 = new InitializableContainer(container1.value)
-
-    val containers = MultipleContainers(container1, container2)
-
-    new TestSpec({
-      assert(1 == 1)
-    }, containers).run(None, Args(mock[Reporter]))
-
-    assert(container1.value == "after start value")
-    assert(container2.value == null)
-  }
-
-  it should "compile HList type inference" in {
-    import shapeless._
-
-    val container1 = new InitializableContainer("after start value")
-    val container2 = new ExampleContainerWithVariable("test")
-
-    val containers = MultipleContainers(container1, container2)
-
-    val c1 :: c2 :: HNil = containers.containers
-
-    assert(c1.value == null)
-    assert(c2.variable == "test")
   }
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.16.1-SNAPSHOT"
+version in ThisBuild := "0.17.0-SNAPSHOT"


### PR DESCRIPTION
Main points:

* Removed `shapeless` dependency.
* Added implicit conversion to `LazyContainer`. This gives you a possibility to not wrap your containers into the `LazyContainer` manually.
* `MultipleContainers.apply` now receives `LazyContainer[_]*` type. Together with the previous point, it makes usage experience of `MultipleContainers` more smooth.

```scala
// before
lazy val pgContainer = PostgreSQLContainer()
lazy val appContainer = AppContainer(pgContainer.jdbcUrl, pgContainer.username, pgContainer.password)
val containers = MultipleContainers(LazyContainer(pgContainer), LazyContainer(appContainer))

//after
lazy val pgContainer = PostgreSQLContainer()
lazy val appContainer = AppContainer(pgContainer.jdbcUrl, pgContainer.username, pgContainer.password)
val containers = MultipleContainers(pgContainer, appContainer)
```

Usage for non-dependent containers should not be affected.


Also, I improved documentation about `MultipleContainers`. And I removed all destructuring examples and changed it to plain old variables declaration. For example:
```scala
// before
val containers = MultipleContainers(new FooContainer(), new BarContainer("test"))
val c1 :: c2 :: HNil = containers.containers

// after
val c1 = new FooContainer()
val c2 = new BarContainer("test")
val containers = MultipleContainers(c1, c2)
```
The second code feels a lot more natural for me. At first, I created all my containers explicitly. This explicit declaration gives me a possibility to use this containers in my test code. And after that, I passed them into the `MultipleContainers`. 

Moreover, in case of dependent container you just have no other option: you need to define your containers explicitly with `lazy val` to pass parameters from one to another. And I think the unification of API for dependent and non-dependent containers is a good thing.
