### PR TITLE
Update testContainer Version to 1.8.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 import xerial.sbt.Sonatype._
 import ReleaseTransformations._
 
-val testcontainersVersion = "1.8.0"
+val testcontainersVersion = "1.8.2"
 val seleniumVersion = "2.53.0"
 val slf4jVersion = "1.7.21"
 val scalaTestVersion = "3.0.1"


### PR DESCRIPTION
I started to work on this, because it fixes my problem with the private Google Container Registry. 

I'm not sure how to proceed, because on my machine, one of the test suites fails with 
````
com.dimafeng.testcontainers.integration.SeleniumSpec *** ABORTED ***
[info]   java.io.IOException: Error detected parsing the header
[info]   at org.apache.commons.compress.archivers.tar.TarArchiveInputStream.getNextTarEntry(TarArchiveInputStream.java:285)
(...)
[info]   ...
[info]   Cause: java.lang.IllegalArgumentException: Invalid byte 15 at offset 0 in '����/' len=8
[info]   at org.apache.commons.compress.archivers.tar.TarUtils.parseOctal(TarUtils.java:141)
(...)
````

On master, I have four failing suites, so I don't exactly know how I could solve this. I'd be happy to help, but I guess I need some guidance.
 
I'm already on docker client version 18.06.0-ce-mac70 on macOs High Sierra 10.13.6