### PR TITLE
Upgrade testcontainers version to 1.9.1 and added versions in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ class GenericContainerSpec extends FlatSpec with ForAllTestContainer {
 
 ```scala
 class ComposeSpec extends FlatSpec with ForAllTestContainer {
-  override val container = DockerComposeContainer(new File("src/test/resources/docker-compose.yml"), exposedService = Map("redis_1" -> 6379))
+  override val container = DockerComposeContainer(new File("src/test/resources/docker-compose.yml"), exposedServices = Seq(ExposedService("redis_1", 6379)))
 
   "DockerComposeContainer" should "retrieve non-0 port for any of services" in {
     assert(container.getServicePort("redis_1", 6379) > 0)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 import xerial.sbt.Sonatype._
 import ReleaseTransformations._
 
-val testcontainersVersion = "1.8.3"
+val testcontainersVersion = "1.9.1"
 val seleniumVersion = "2.53.0"
 val slf4jVersion = "1.7.21"
 val scalaTestVersion = "3.0.1"

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -1,4 +1,4 @@
 redis:
-  image: redis
+  image: redis:5.0.0
 elasticsearch:
-  image: elasticsearch
+  image: elasticsearch:6.4.1

--- a/src/test/scala/com/dimafeng/testcontainers/integration/ComposeSpec.scala
+++ b/src/test/scala/com/dimafeng/testcontainers/integration/ComposeSpec.scala
@@ -2,11 +2,11 @@ package com.dimafeng.testcontainers.integration
 
 import java.io.File
 
-import com.dimafeng.testcontainers.{ForAllTestContainer, DockerComposeContainer}
+import com.dimafeng.testcontainers.{DockerComposeContainer, ExposedService, ForAllTestContainer}
 import org.scalatest.FlatSpec
 
 class ComposeSpec extends FlatSpec with ForAllTestContainer {
-  override val container = DockerComposeContainer(new File("src/test/resources/docker-compose.yml"), Map("redis_1" -> 6379))
+  override val container = DockerComposeContainer(new File("src/test/resources/docker-compose.yml"), Seq(ExposedService("redis_1", 6379)))
 
   "DockerComposeContainer" should "retrieve non-0 port for any of services" in {
     assert(container.getServicePort("redis_1", 6379) > 0)
@@ -14,5 +14,5 @@ class ComposeSpec extends FlatSpec with ForAllTestContainer {
 }
 
 class ComposeSpecWithImplicitConversions extends ComposeSpec {
-  override val container = DockerComposeContainer(Seq(new File("src/test/resources/docker-compose.yml")), exposedService = Map("redis_1" -> 6379))
+  override val container = DockerComposeContainer(Seq(new File("src/test/resources/docker-compose.yml")), exposedServices = Seq(ExposedService("redis_1", 6379)))
 }


### PR DESCRIPTION
Figured out that the failing tests in #30 were due to the fact that `elasticsearch:latest` is not available in Docker Hub anymore... so added versions in `docker-compose.yml` to prevent this from happening in the future and moving on :smile: 

On a side note current master is not building as well because of that same issue...

@bskarda @dimafeng 