### PR TITLE
Deprecate old lifecycle methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ class MysqlSpec extends FlatSpec with ForAllTestContainer {
 
 ## Release notes
 
+* **0.27.0**
+    * New `TestLifecycleAware` trait introduced. You can use it when you want to do something with the container before or after the test.
+    * `Container` now implements `Startable` interface with `start` and `stop` methods.
+    * Old container's lifecycle methods `finished`, `succeeded`, `starting`, `failed` are deprecated. Use `start`, `stop`, and `TestLifecycleAware` methods instead.
+
 * **0.26.0**
     * TestContainers `1.11.2` -> `1.11.3`
     * Scala 2.13.0

--- a/src/main/scala/com/dimafeng/testcontainers/DockerComposeContainer.scala
+++ b/src/main/scala/com/dimafeng/testcontainers/DockerComposeContainer.scala
@@ -111,4 +111,7 @@ class DockerComposeContainer (composeFiles: ComposeFile,
 
   def getServicePort(serviceName: String, servicePort: Int): Int = container.getServicePort(serviceName, servicePort)
 
+  override def start(): Unit = container.start()
+
+  override def stop(): Unit = container.stop()
 }

--- a/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala
+++ b/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala
@@ -1,18 +1,36 @@
 package com.dimafeng.testcontainers
 
+import com.dimafeng.testcontainers.lifecycle.TestLifecycleAware
 import org.junit.runner.Description
+import org.testcontainers.lifecycle.TestDescription
 
 import scala.language.implicitConversions
 
-class MultipleContainers private(containers: Seq[LazyContainer[_]]) extends Container {
+class MultipleContainers private(containers: Seq[LazyContainer[_]]) extends Container with TestLifecycleAware {
 
+  @deprecated("Use `stop` instead")
   override def finished()(implicit description: Description): Unit = containers.foreach(_.finished()(description))
 
+  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
   override def succeeded()(implicit description: Description): Unit = containers.foreach(_.succeeded()(description))
 
+  @deprecated("Use `start` instead")
   override def starting()(implicit description: Description): Unit = containers.foreach(_.starting()(description))
 
+  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
   override def failed(e: Throwable)(implicit description: Description): Unit = containers.foreach(_.failed(e)(description))
+
+  override def beforeTest(description: TestDescription): Unit = {
+    containers.foreach(_.beforeTest(description))
+  }
+
+  override def afterTest(description: TestDescription, throwable: Option[Throwable]): Unit = {
+    containers.foreach(_.afterTest(description, throwable))
+  }
+
+  override def start(): Unit = containers.foreach(_.start())
+
+  override def stop(): Unit = containers.foreach(_.stop())
 }
 
 object MultipleContainers {
@@ -47,16 +65,38 @@ object MultipleContainers {
   * You don't need to wrap your containers into the `LazyContainer` manually
   * when you pass your containers in the `MultipleContainers`- there is implicit conversion for that.
   */
-class LazyContainer[T <: Container](factory: => T) extends Container {
+class LazyContainer[T <: Container](factory: => T) extends Container with TestLifecycleAware {
   lazy val container: T = factory
 
+  @deprecated("Use `stop` instead")
   override def finished()(implicit description: Description): Unit = container.finished
 
+  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
   override def failed(e: Throwable)(implicit description: Description): Unit = container.failed(e)
 
+  @deprecated("Use `start` instead")
   override def starting()(implicit description: Description): Unit = container.starting()
 
+  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
   override def succeeded()(implicit description: Description): Unit = container.succeeded()
+
+  override def beforeTest(description: TestDescription): Unit = {
+    container match {
+      case c: TestLifecycleAware => c.beforeTest(description)
+      case _ => // do nothing
+    }
+  }
+
+  override def afterTest(description: TestDescription, throwable: Option[Throwable]): Unit = {
+    container match {
+      case c: TestLifecycleAware => c.afterTest(description, throwable)
+      case _ => // do nothing
+    }
+  }
+
+  override def start(): Unit = container.start()
+
+  override def stop(): Unit = container.stop()
 }
 
 object LazyContainer {

--- a/src/main/scala/com/dimafeng/testcontainers/SeleniumTestContainerSuite.scala
+++ b/src/main/scala/com/dimafeng/testcontainers/SeleniumTestContainerSuite.scala
@@ -2,11 +2,14 @@ package com.dimafeng.testcontainers
 
 import java.io.File
 import java.net.URL
+import java.util.Optional
 
+import com.dimafeng.testcontainers.lifecycle.TestLifecycleAware
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.remote.{DesiredCapabilities, RemoteWebDriver}
 import org.scalatest.Suite
 import org.testcontainers.containers.BrowserWebDriverContainer
+import org.testcontainers.lifecycle.TestDescription
 
 
 trait SeleniumTestContainerSuite extends ForEachTestContainer {
@@ -23,7 +26,7 @@ trait SeleniumTestContainerSuite extends ForEachTestContainer {
 
 class SeleniumContainer(desiredCapabilities: Option[DesiredCapabilities] = None,
                         recordingMode: Option[(BrowserWebDriverContainer.VncRecordingMode, File)] = None)
-  extends SingleContainer[BrowserWebDriverContainer[_]] {
+  extends SingleContainer[BrowserWebDriverContainer[_]] with TestLifecycleAware {
   require(desiredCapabilities.isDefined, "'desiredCapabilities' is required parameter")
 
   type OTCContainer = BrowserWebDriverContainer[T] forSome {type T <: BrowserWebDriverContainer[T]}
@@ -40,6 +43,14 @@ class SeleniumContainer(desiredCapabilities: Option[DesiredCapabilities] = None,
   def vncAddress: String = container.getVncAddress
 
   def webDriver: RemoteWebDriver = container.getWebDriver
+
+  override def afterTest(description: TestDescription, throwable: Option[Throwable]): Unit = {
+    val javaThrowable: Optional[Throwable] = throwable match {
+      case Some(error) => Optional.of(error)
+      case None => Optional.empty()
+    }
+    container.afterTest(description, javaThrowable)
+  }
 }
 
 object SeleniumContainer {

--- a/src/main/scala/com/dimafeng/testcontainers/lifecycle/TestLifecycleAware.scala
+++ b/src/main/scala/com/dimafeng/testcontainers/lifecycle/TestLifecycleAware.scala
@@ -1,0 +1,10 @@
+package com.dimafeng.testcontainers.lifecycle
+
+import org.testcontainers.lifecycle.TestDescription
+
+trait TestLifecycleAware {
+
+  def beforeTest(description: TestDescription): Unit = {}
+
+  def afterTest(description: TestDescription, throwable: Option[Throwable]): Unit = {}
+}

--- a/src/main/scala/org/testcontainers/containers/TestContainerAccessor.scala
+++ b/src/main/scala/org/testcontainers/containers/TestContainerAccessor.scala
@@ -2,6 +2,7 @@ package org.testcontainers.containers
 
 import org.junit.runner.Description
 
+@deprecated("Should be replaced by lifecycle methods")
 object TestContainerAccessor {
   def finished[T <:FailureDetectingExternalResource](description: Description)(implicit container: T): Unit =
     container.finished(description)

--- a/src/test/scala/com/dimafeng/testcontainers/MultipleContainersSpec.scala
+++ b/src/test/scala/com/dimafeng/testcontainers/MultipleContainersSpec.scala
@@ -1,12 +1,15 @@
 package com.dimafeng.testcontainers
 
+import java.util.Optional
+
 import com.dimafeng.testcontainers.ContainerSpec.{SampleContainer, SampleOTCContainer}
-import com.dimafeng.testcontainers.MultipleContainersSpec.{ExampleContainerWithVariable, InitializableContainer, TestSpec}
+import com.dimafeng.testcontainers.MultipleContainersSpec.{InitializableContainer, TestSpec}
 import org.junit.runner.Description
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{times, verify}
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.Mockito.verify
 import org.scalatest.{Args, FlatSpec, Reporter}
+import org.scalatestplus.mockito.MockitoSugar
 
 class MultipleContainersSpec extends BaseSpec[ForEachTestContainer] {
   it should "call all expected methods of the multiple containers" in {
@@ -19,14 +22,15 @@ class MultipleContainersSpec extends BaseSpec[ForEachTestContainer] {
       assert(1 == 1)
     }, containers).run(None, Args(mock[Reporter]))
 
-    verify(container1).starting(any())
-    verify(container1, times(0)).failed(any(), any())
-    verify(container1).finished(any())
-    verify(container1).succeeded(any())
-    verify(container2).starting(any())
-    verify(container2, times(0)).failed(any(), any())
-    verify(container2).finished(any())
-    verify(container2).succeeded(any())
+    verify(container1).beforeTest(any())
+    verify(container1).start()
+    verify(container1).afterTest(any(), ArgumentMatchers.eq(Optional.empty()))
+    verify(container1).stop()
+
+    verify(container2).beforeTest(any())
+    verify(container2).start()
+    verify(container2).afterTest(any(), ArgumentMatchers.eq(Optional.empty()))
+    verify(container2).stop()
   }
 
   /**
@@ -53,15 +57,9 @@ object MultipleContainersSpec {
     override implicit val container: SampleOTCContainer = mock[SampleOTCContainer]
     var value: String = _
 
-    override def finished()(implicit description: Description): Unit = ()
-
-    override def succeeded()(implicit description: Description): Unit = ()
-
-    override def starting()(implicit description: Description): Unit = {
+    override def start(): Unit = {
       value = valueToBeSetAfterStart
     }
-
-    override def failed(e: Throwable)(implicit description: Description): Unit = ()
   }
 
   class ExampleContainerWithVariable(val variable: String) extends SingleContainer[SampleOTCContainer] with MockitoSugar {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.26.1-SNAPSHOT"
+version in ThisBuild := "0.27.0-SNAPSHOT"


### PR DESCRIPTION
testcontainers-java reworked lifecycle of the containers a bit. This pull request is to support these changes.

* New `TestLifecycleAware` trait introduced. It's a copy of java's interface, but with scala's `Option` type. Users of the library can use it when they want to do something with the container before or after the test. Personally, I'm against this feature at all, but I didn't convince the core java team that this feature is redundant. So, we have to support this. Also, I could just reuse java's interface, but I don't think that it's a good idea. Scala's hierarchy is completely separate from the java's, and it would be very unnatural for the scala users to work with the java's Optional.
* `Container` now implements `Startable` java interface with `start` and `stop` methods.. I didn't copy this interface, because it's absolutely minimal and usable from the scala side.
* `ForEachTestContainer` and `ForAllTestContainer` now uses new lifecycle methods.
* They are also a bit improved internally. These improvements are based on my work on the new API, but not related to the new API directly:
    * I handled few multithreaded corner cases with `volatile`.
    * Improved test description for error messages.
    * `ForAllTestContainer` now supports `afterTest`/`beforeTest`.
* `SeleniumContainer` now implements TestLifecycleAware.
* `MultipleContainers` and `LazyContainer` are implements `TestLifecycleAware` too, because they could contain containers with `TestLifecycleAware`.
* Old lifecycle code, like `finished`, `succeeded`, `starting`, `failed` methods, are marked as deprecated.
* Tests are updated.
* I bumped a version to 0.27.0-SNAPSHOT, because of deprecations.