### PR TITLE
Adding more configuration options to PostgresSQLContainer

### DIFF
--- a/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala
+++ b/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala
@@ -2,7 +2,11 @@ package com.dimafeng.testcontainers
 
 import org.testcontainers.containers.{PostgreSQLContainer => OTCPostgreSQLContainer}
 
-class PostgreSQLContainer(dockerImageNameOverride: Option[String] = None) extends SingleContainer[OTCPostgreSQLContainer[_]] {
+class PostgreSQLContainer(dockerImageNameOverride: Option[String] = None,
+                          databaseName: Option[String] = None,
+                          pgUsername: Option[String] = None,
+                          pgPassword: Option[String] = None,
+                          mountPostgresDataToTmpfs: Boolean = false) extends SingleContainer[OTCPostgreSQLContainer[_]] {
 
   type OTCContainer = OTCPostgreSQLContainer[T] forSome {type T <: OTCPostgreSQLContainer[T]}
 
@@ -13,6 +17,19 @@ class PostgreSQLContainer(dockerImageNameOverride: Option[String] = None) extend
 
     case None =>
       new OTCPostgreSQLContainer()
+  }
+
+  databaseName.map(container.withDatabaseName)
+  pgUsername.map(container.withUsername)
+  pgPassword.map(container.withPassword)
+
+  // as suggested in https://github.com/testcontainers/testcontainers-java/issues/1256
+  // mounting the postgres data directory to an in-memory docker volume (https://docs.docker.com/storage/tmpfs/)
+  // can improve performance
+  if (mountPostgresDataToTmpfs){
+    val tmpfsMount = new java.util.HashMap[String, String]()
+    tmpfsMount.put("/var/lib/postgresql/data", "rw")
+    container.withTmpFs(tmpfsMount)
   }
 
   def driverClassName: String = container.getDriverClassName
@@ -27,5 +44,17 @@ class PostgreSQLContainer(dockerImageNameOverride: Option[String] = None) extend
 }
 
 object PostgreSQLContainer {
-  def apply(dockerImageNameOverride: String = null): PostgreSQLContainer = new PostgreSQLContainer(Option(dockerImageNameOverride))
+  def apply(dockerImageNameOverride: String = null,
+            databaseName: String = null,
+            username: String = null,
+            password: String = null,
+            mountPostgresDataToTmpfs: Boolean = false,
+           ): PostgreSQLContainer =
+    new PostgreSQLContainer(
+      Option(dockerImageNameOverride),
+      Option(databaseName),
+      Option(username),
+      Option(password),
+      mountPostgresDataToTmpfs
+    )
 }


### PR DESCRIPTION
This PR contains the following:

- added options to specify postgres database configuration for
  databaseName, username and password, which can now be defined when
  instantiating a new container

- added configuration option mountPostgresDataToTmpfs, which allows to
  mount the postgres data directory (/var/lib/postgresql/data) inside
  the docker container to an in-memory volume for improved performance
  (see https://github.com/testcontainers/testcontainers-java/issues/1256)