### PR TITLE
Removed existential types from containers

### DIFF
--- a/core/src/main/scala/com/dimafeng/testcontainers/DockerComposeContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/DockerComposeContainer.scala
@@ -75,10 +75,8 @@ class DockerComposeContainer(composeFiles: ComposeFile,
                              logConsumers: Seq[ServiceLogConsumer] = Seq.empty)
   extends TestContainerProxy[OTCDockerComposeContainer[_]] {
 
-  type OTCContainer = OTCDockerComposeContainer[T] forSome {type T <: OTCDockerComposeContainer[T]}
-
-  override val container: OTCContainer = {
-    val container: OTCContainer = new OTCDockerComposeContainer(identifier, composeFiles match {
+  override val container: OTCDockerComposeContainer[_] = {
+    val container: OTCDockerComposeContainer[_] = new OTCDockerComposeContainer(identifier, composeFiles match {
       case ComposeFile(Left(f)) => util.Arrays.asList(f)
       case ComposeFile(Right(files)) => files.asJava
     })

--- a/core/src/main/scala/com/dimafeng/testcontainers/FixedHostPortGenericContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/FixedHostPortGenericContainer.scala
@@ -13,8 +13,7 @@ class FixedHostPortGenericContainer(imageName: String,
                                     exposedContainerPort: Int
                                    ) extends SingleContainer[OTCFixedHostPortGenericContainer[_]] {
 
-  type FixedHostPortContainer = OTCFixedHostPortGenericContainer[T] forSome {type T <: OTCFixedHostPortGenericContainer[T]}
-  override implicit val container: FixedHostPortContainer = new OTCFixedHostPortGenericContainer(imageName)
+  override implicit val container: OTCFixedHostPortGenericContainer[_] = new OTCFixedHostPortGenericContainer(imageName)
 
   if (exposedPorts.nonEmpty) {
     container.withExposedPorts(exposedPorts.map(int2Integer): _*)

--- a/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
@@ -14,8 +14,7 @@ class GenericContainer(dockerImage: DockerImage,
                        waitStrategy: Option[WaitStrategy] = None
                       ) extends SingleContainer[OTCGenericContainer[_]] {
 
-  type OTCContainer = OTCGenericContainer[T] forSome {type T <: OTCGenericContainer[T]}
-  override implicit val container: OTCContainer = dockerImage match {
+  override implicit val container: OTCGenericContainer[_] = dockerImage match {
     case DockerImage(Left(imageFromDockerfile)) => new OTCGenericContainer(imageFromDockerfile)
     case DockerImage(Right(imageName))          => new OTCGenericContainer(imageName)
   }

--- a/modules/cassandra/src/main/scala/com/dimafeng/testcontainers/CassandraContainer.scala
+++ b/modules/cassandra/src/main/scala/com/dimafeng/testcontainers/CassandraContainer.scala
@@ -7,9 +7,7 @@ class CassandraContainer(dockerImageNameOverride: Option[String] = None,
                          initScript: Option[String] = None,
                          jmxReporting: Boolean = false) extends SingleContainer[OTCCassandraContainer[_]] {
 
-  type OTCContainer = OTCGenericContainer[T] forSome {type T <: OTCCassandraContainer[T]}
-
-  val cassandraContainer: OTCCassandraContainer[Nothing] = {
+  val cassandraContainer: OTCCassandraContainer[_] = {
     if (dockerImageNameOverride.isEmpty) {
       new OTCCassandraContainer()
     } else {

--- a/modules/kafka/src/main/scala/com/dimafeng/testcontainers/KafkaContainer.scala
+++ b/modules/kafka/src/main/scala/com/dimafeng/testcontainers/KafkaContainer.scala
@@ -1,11 +1,9 @@
 package com.dimafeng.testcontainers
 
-import org.testcontainers.containers.{GenericContainer => OTCGenericContainer, KafkaContainer => OTCKafkaContainer}
+import org.testcontainers.containers.{KafkaContainer => OTCKafkaContainer}
 
 class KafkaContainer(confluentPlatformVersion: Option[String] = None,
-                     externalZookeeper: Option[String] = None) extends SingleContainer[OTCGenericContainer[_]] {
-
-  type OTCContainer = OTCGenericContainer[T] forSome {type T <: OTCKafkaContainer}
+                     externalZookeeper: Option[String] = None) extends SingleContainer[OTCKafkaContainer] {
 
   @deprecated("Please use reflective methods of the scala container or `configure` method")
   val kafkaContainer: OTCKafkaContainer = {

--- a/modules/mysql/src/main/scala/com/dimafeng/testcontainers/MySQLContainer.scala
+++ b/modules/mysql/src/main/scala/com/dimafeng/testcontainers/MySQLContainer.scala
@@ -11,10 +11,7 @@ class MySQLContainer(configurationOverride: Option[String] = None,
                      mysqlPassword: Option[String] = None)
   extends SingleContainer[OTCMySQLContainer[_]] {
 
-  type OTCContainer = OTCMySQLContainer[T] forSome {
-    type T <: OTCMySQLContainer[T]
-  }
-  override val container: OTCContainer = mysqlImageVersion
+  override val container: OTCMySQLContainer[_] = mysqlImageVersion
     .map(new OTCMySQLContainer(_))
     .getOrElse(new OTCMySQLContainer(DEFAULT_MYSQL_VERSION))
 

--- a/modules/postgres/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala
+++ b/modules/postgres/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala
@@ -8,9 +8,7 @@ class PostgreSQLContainer(dockerImageNameOverride: Option[String] = None,
                           pgPassword: Option[String] = None,
                           mountPostgresDataToTmpfs: Boolean = false) extends SingleContainer[OTCPostgreSQLContainer[_]] {
 
-  type OTCContainer = OTCPostgreSQLContainer[T] forSome {type T <: OTCPostgreSQLContainer[T]}
-
-  override val container: OTCContainer = dockerImageNameOverride match {
+  override val container: OTCPostgreSQLContainer[_] = dockerImageNameOverride match {
 
     case Some(imageNameOverride) =>
       new OTCPostgreSQLContainer(imageNameOverride)

--- a/modules/vault/src/main/scala/com/dimafeng/testcontainers/VaultContainer.scala
+++ b/modules/vault/src/main/scala/com/dimafeng/testcontainers/VaultContainer.scala
@@ -1,13 +1,10 @@
 package com.dimafeng.testcontainers;
 
-import org.testcontainers.containers.{GenericContainer => OTCGenericContainer}
 import org.testcontainers.vault.{VaultContainer => OTCVaultContainer}
 
 class VaultContainer(dockerImageNameOverride: Option[String] = None,
                      vaultToken: Option[String] = None,
                      vaultPort: Option[Int]) extends SingleContainer[OTCVaultContainer[_]] {
-
-  type OTCContainer = OTCGenericContainer[T] forSome {type T <: OTCVaultContainer[T]}
 
   val vaultContainer: OTCVaultContainer[Nothing] = {
     if (dockerImageNameOverride.isEmpty) {

--- a/test-framework/scalatest-selenium/src/main/scala/com/dimafeng/testcontainers/SeleniumTestContainerSuite.scala
+++ b/test-framework/scalatest-selenium/src/main/scala/com/dimafeng/testcontainers/SeleniumTestContainerSuite.scala
@@ -28,8 +28,7 @@ class SeleniumContainer(desiredCapabilities: Option[DesiredCapabilities] = None,
   extends SingleContainer[BrowserWebDriverContainer[_]] with TestLifecycleAware {
   require(desiredCapabilities.isDefined, "'desiredCapabilities' is required parameter")
 
-  type OTCContainer = BrowserWebDriverContainer[T] forSome {type T <: BrowserWebDriverContainer[T]}
-  override val container: OTCContainer = new BrowserWebDriverContainer()
+  override val container: BrowserWebDriverContainer[_] = new BrowserWebDriverContainer()
   desiredCapabilities.foreach(container.withDesiredCapabilities)
   recordingMode.foreach(Function.tupled(container.withRecordingMode))
 


### PR DESCRIPTION
This change is a minor simplification of an inner codebase.

1. We don't need this kind of types and can replace them with just `SomeType[_]` (without `forSome`) because we don't have any specific usage of existential types in the codebase.
2. We can remove them because they are not a part of a public API.
3. In scala 3 existential types [will be dropped](https://dotty.epfl.ch/docs/reference/dropped-features/existential-types.html)