### PR TITLE
Define container as `def`, not `val`

### DIFF
--- a/test-framework/scalatest/src/main/scala/com/dimafeng/testcontainers/TestContainers.scala
+++ b/test-framework/scalatest/src/main/scala/com/dimafeng/testcontainers/TestContainers.scala
@@ -30,7 +30,7 @@ private[testcontainers] object TestContainers {
 
   trait TestContainersSuite extends SuiteMixin { self: Suite =>
 
-    val container: Container
+    def container: Container
 
     def afterStart(): Unit = {}
 


### PR DESCRIPTION
Fixes #81 

Ran `sbt test` and it doesn't seem there is any regression.