### PR TITLE
Fixing aggregated module deploy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,12 +65,11 @@ lazy val root = (project in file("."))
     modulePostgres,
     moduleCassandra,
     moduleKafka,
-    moduleVault
+    moduleVault,
+    allOld
   )
   .settings(noPublishSettings)
   .settings(
-    name := "testcontainers-scala",
-
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       inquireVersions,


### PR DESCRIPTION
Microfix for publishing `allOld` project. I managed to use `sbt release` with `+publishLocal` instead of `+publishSinged` all it seems it works fine.