### PR TITLE
Fixing pom.xml for allOld package

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,13 +1,97 @@
 import sbt._
 
 object Dependencies {
-  def COMPILE(modules: sbt.ModuleID*): Seq[sbt.ModuleID] = deps(None, modules: _*)
+  private def COMPILE(modules: sbt.ModuleID*): Seq[sbt.ModuleID] = deps(None, modules: _*)
 
-  def PROVIDED(modules: sbt.ModuleID*): Seq[sbt.ModuleID] = deps(Some("provided"), modules: _*)
+  private def PROVIDED(modules: sbt.ModuleID*): Seq[sbt.ModuleID] = deps(Some("provided"), modules: _*)
 
-  def TEST(modules: sbt.ModuleID*): Seq[sbt.ModuleID] = deps(Some("test"), modules: _*)
+  private def TEST(modules: sbt.ModuleID*): Seq[sbt.ModuleID] = deps(Some("test"), modules: _*)
 
-  def deps(scope: Option[String], modules: sbt.ModuleID*): Seq[sbt.ModuleID] = {
+  private def deps(scope: Option[String], modules: sbt.ModuleID*): Seq[sbt.ModuleID] = {
     scope.map(s => modules.map(_ % s)).getOrElse(modules)
   }
+
+  private val testcontainersVersion = "1.12.2"
+  private val seleniumVersion = "2.53.1"
+  private val slf4jVersion = "1.7.25"
+  private val scalaTestVersion = "3.0.8"
+  private val mysqlConnectorVersion = "5.1.42"
+  private val cassandraDriverVersion = "4.0.1"
+  private val postgresqlDriverVersion = "9.4.1212"
+  private val kafkaDriverVersion = "2.2.0"
+  private val mockitoVersion = "2.27.0"
+  private val restAssuredVersion = "4.0.0"
+
+  val allOld = Def.setting(
+    PROVIDED(
+      "org.scalatest" %% "scalatest" % scalaTestVersion
+    )
+  )
+
+  val core = Def.setting(
+    COMPILE(
+      "org.testcontainers" % "testcontainers" % testcontainersVersion
+    ) ++ PROVIDED(
+      "org.slf4j" % "slf4j-simple" % slf4jVersion
+    ) ++ TEST(
+      "junit" % "junit" % "4.12",
+      "org.scalatest" %% "scalatest" % scalaTestVersion,
+      "org.testcontainers" % "selenium" % testcontainersVersion,
+      "org.postgresql" % "postgresql" % postgresqlDriverVersion,
+      "org.mockito" % "mockito-core" % mockitoVersion
+    )
+  )
+
+  val scalatest = Def.setting(
+    PROVIDED(
+      "org.scalatest" %% "scalatest" % scalaTestVersion
+    )
+  )
+
+  val scalatestSelenium = Def.setting(
+    COMPILE(
+      "org.testcontainers" % "selenium" % testcontainersVersion,
+      "org.seleniumhq.selenium" % "selenium-java" % seleniumVersion
+    )
+  )
+
+  val moduleMysql = Def.setting(
+    COMPILE(
+      "org.testcontainers" % "mysql" % testcontainersVersion
+    ) ++ TEST(
+      "mysql" % "mysql-connector-java" % mysqlConnectorVersion
+    )
+  )
+
+  val modulePostgres = Def.setting(
+    COMPILE(
+      "org.testcontainers" % "postgresql" % testcontainersVersion
+    ) ++ TEST(
+      "org.postgresql" % "postgresql" % postgresqlDriverVersion
+    )
+  )
+
+  val moduleCassandra = Def.setting(
+    COMPILE(
+      "org.testcontainers" % "cassandra" % testcontainersVersion,
+    ) ++ TEST(
+      "com.datastax.oss" % "java-driver-core" % cassandraDriverVersion,
+    )
+  )
+
+  val moduleKafka = Def.setting(
+    COMPILE(
+      "org.testcontainers" % "kafka" % testcontainersVersion
+    ) ++ TEST(
+      "org.apache.kafka" % "kafka-clients" % kafkaDriverVersion,
+    )
+  )
+
+  val moduleVault = Def.setting(
+    COMPILE(
+      "org.testcontainers" % "vault" % testcontainersVersion,
+    ) ++ TEST(
+      "io.rest-assured" % "scala-support" % restAssuredVersion
+    )
+  )
 }


### PR DESCRIPTION
To maintain `allOld` package fully backward compatible we need to:
1. Exclude compile transitive dependencies from `com.dimafeng:*` modules.
2. Re-add this compile transitive dependencies with the `provided` configuration.

With this, we will produce `pom.xml` with the same effects as the old `pom.xml` file.

To achieve this I had to use some sbt black magic. 

What actually done here:
* I moved all dependencies declarations to the `Dependencies` file. I need it to reuse dependencies from .different projects. And overall it is a good practice to do this because it makes your `build.sbt` file less noisy.
* I removed all extra modifiers in `dependsOn` block in `allOld` project. It gives nothing in my case.
* I added a `pomPostProcess` step. That's where the fun begins. I actually rewrite some parts of the `pom.xml` file on the fly. The code is massive, but I hope is it readable enough. In this step, I excluded compile transitive dependencies from `pom.xml` through the `<exclusions>` blocks.
* I added excluded dependencies to the `allOld` project from the transitive with configuration rewrite from `compile` to `provided`.