### PR TITLE
Improvements in the new api

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,13 @@ If you have any questions or difficulties feel free to ask it in our [slack chan
 
 ## Release notes
 
+* **0.34.1**
+    * New API improvements:
+        * Changed signature of `def withContainers(runTest: Containers => Unit): Unit` to 
+        `def withContainers[A](runTest: Containers => A): A`
+        * Renamed `afterStart` to `afterContainersStart` and added a `containers: Containers` argument to it.
+        * Renamed `beforeStop` to `beforeContainersStop` and added a `containers: Containers` argument to it.
+
 * **0.34.0**
     * Added new, experimental API and DSL.
       The main motivation points are in the [pull request](https://github.com/testcontainers/testcontainers-scala/pull/78). 

--- a/test-framework/scalatest/src/main/scala/com/dimafeng/testcontainers/scalatest/TestContainersForAll.scala
+++ b/test-framework/scalatest/src/main/scala/com/dimafeng/testcontainers/scalatest/TestContainersForAll.scala
@@ -36,13 +36,14 @@ trait TestContainersForAll extends TestContainersSuite { self: Suite =>
     if (expectedTestCount(args.filter) == 0) {
       new CompositeStatus(Set.empty)
     } else {
-      startedContainers = Some(startContainers())
+      val containers = startContainers()
+      startedContainers = Some(containers)
       try {
-        afterStart()
+        afterContainersStart(containers)
         super.run(testName, args)
       } finally {
         try {
-          beforeStop()
+          beforeContainersStop(containers)
         }
         finally {
           try {

--- a/test-framework/scalatest/src/main/scala/com/dimafeng/testcontainers/scalatest/TestContainersForEach.scala
+++ b/test-framework/scalatest/src/main/scala/com/dimafeng/testcontainers/scalatest/TestContainersForEach.scala
@@ -40,7 +40,7 @@ trait TestContainersForEach extends TestContainersSuite { self: Suite =>
     @volatile var afterTestCalled = false
 
     try {
-      afterStart()
+      afterContainersStart(containers)
       beforeTest(containers)
 
       testCalled = true
@@ -67,7 +67,7 @@ trait TestContainersForEach extends TestContainersSuite { self: Suite =>
     }
     finally {
       try {
-        beforeStop()
+        beforeContainersStop(containers)
       }
       finally {
         try {

--- a/test-framework/scalatest/src/main/scala/com/dimafeng/testcontainers/scalatest/TestContainersSuite.scala
+++ b/test-framework/scalatest/src/main/scala/com/dimafeng/testcontainers/scalatest/TestContainersSuite.scala
@@ -61,7 +61,7 @@ private[scalatest] trait TestContainersSuite extends SuiteMixin { self: Suite =>
     *
     * @param runTest Test body
     */
-  def withContainers(runTest: Containers => Unit): Unit = {
+  def withContainers[A](runTest: Containers => A): A = {
     val c = startedContainers.getOrElse(throw IllegalWithContainersCall())
     runTest(c)
   }
@@ -69,12 +69,12 @@ private[scalatest] trait TestContainersSuite extends SuiteMixin { self: Suite =>
   /**
     * Override, if you want to do something after containers start.
     */
-  def afterStart(): Unit = {}
+  def afterContainersStart(containers: Containers): Unit = {}
 
   /**
     * Override, if you want to do something before containers stop.
     */
-  def beforeStop(): Unit = {}
+  def beforeContainersStop(containers: Containers): Unit = {}
 
   @volatile private[testcontainers] var startedContainers: Option[Containers] = None
 

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/scalatest/TestContainerForAllSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/scalatest/TestContainerForAllSpec.scala
@@ -53,17 +53,17 @@ class TestContainerForAllSpec extends BaseSpec[TestContainerForAll] {
     verify(container).stop()
   }
 
-  it should "call afterStart() and beforeStop()" in {
+  it should "call afterContainersStart() and beforeContainersStop()" in {
     val container = mock[SampleJavaContainer]
 
     val spec = Mockito.spy(new MultipleTestsSpec({}, SampleContainer.Def(container)))
     spec.run(None, Args(mock[Reporter]))
 
-    verify(spec).afterStart()
-    verify(spec).beforeStop()
+    verify(spec).afterContainersStart(any())
+    verify(spec).beforeContainersStop(any())
   }
 
-  it should "call beforeStop() and stop container if error thrown in afterStart()" in {
+  it should "call beforeContainersStop() and stop container if error thrown in afterContainersStart()" in {
     val container = mock[SampleJavaContainer]
 
     val spec = Mockito.spy(new MultipleTestsSpecWithFailedAfterStart({}, SampleContainer.Def(container)))
@@ -72,9 +72,9 @@ class TestContainerForAllSpec extends BaseSpec[TestContainerForAll] {
     }
     verify(container, times(0)).beforeTest(any())
     verify(container).start()
-    verify(spec).afterStart()
+    verify(spec).afterContainersStart(any())
     verify(container, times(0)).afterTest(any(), any())
-    verify(spec).beforeStop()
+    verify(spec).beforeContainersStop(any())
     verify(container).stop()
   }
 
@@ -116,7 +116,8 @@ object TestContainerForAllSpec {
 
     override val containerDef: ContainerDef = contDef
 
-    override def afterStart(): Unit = throw new RuntimeException("something wrong in afterStart()")
+    override def afterContainersStart(containers: Containers): Unit =
+      throw new RuntimeException("something wrong in afterContainersStart()")
 
     it should "test1" in {
       testBody

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/scalatest/TestContainerForEachSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/scalatest/TestContainerForEachSpec.scala
@@ -66,16 +66,19 @@ class TestContainerForEachSpec extends BaseSpec[TestContainerForEach] {
   it should "call beforeContainersStop() and stop container if error thrown in afterContainersStart()" in {
     val container = mock[SampleJavaContainer]
 
-    val spec = Mockito.spy(new MultipleTestsSpecWithFailedAfterStart({}, SampleContainer.Def(container)))
+    @volatile var beforeContainersStopCalled = false
+
+    val spec = new MultipleTestsSpecWithFailedAfterStart({}, SampleContainer.Def(container), () => {
+      beforeContainersStopCalled = true
+    })
     intercept[RuntimeException] {
       spec.run(None, Args(mock[Reporter]))
     }
     verify(container, times(0)).beforeTest(any())
     verify(container).start()
-    verify(spec).afterContainersStart(any())
     verify(container, times(0)).afterTest(any(), any())
-    verify(spec).beforeContainersStop(any())
     verify(container).stop()
+    assert(beforeContainersStopCalled)
   }
 
   it should "not start container if all tests are ignored" in {
@@ -112,12 +115,18 @@ object TestContainerForEachSpec {
     }
   }
 
-  protected class MultipleTestsSpecWithFailedAfterStart(testBody: => Unit, contDef: ContainerDef) extends FlatSpec with TestContainerForEach {
+  protected class MultipleTestsSpecWithFailedAfterStart(
+    testBody: => Unit,
+    contDef: ContainerDef,
+    beforeContStop: () => Unit
+  ) extends FlatSpec with TestContainerForEach {
 
     override val containerDef: ContainerDef = contDef
 
     override def afterContainersStart(containers: Containers): Unit =
       throw new RuntimeException("something wrong in afterContainersStart()")
+
+    override def beforeContainersStop(containers: containerDef.Container): Unit = beforeContStop()
 
     it should "test1" in {
       testBody

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/scalatest/TestContainerForEachSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/scalatest/TestContainerForEachSpec.scala
@@ -53,17 +53,17 @@ class TestContainerForEachSpec extends BaseSpec[TestContainerForEach] {
     verify(container, times(2)).stop()
   }
 
-  it should "call afterStart() and beforeStop()" in {
+  it should "call afterContainersStart() and beforeContainersStop()" in {
     val container = mock[SampleJavaContainer]
 
     val spec = Mockito.spy(new MultipleTestsSpec({}, SampleContainer.Def(container)))
     spec.run(None, Args(mock[Reporter]))
 
-    verify(spec, times(2)).afterStart()
-    verify(spec, times(2)).beforeStop()
+    verify(spec, times(2)).afterContainersStart(any())
+    verify(spec, times(2)).beforeContainersStop(any())
   }
 
-  it should "call beforeStop() and stop container if error thrown in afterStart()" in {
+  it should "call beforeContainersStop() and stop container if error thrown in afterContainersStart()" in {
     val container = mock[SampleJavaContainer]
 
     val spec = Mockito.spy(new MultipleTestsSpecWithFailedAfterStart({}, SampleContainer.Def(container)))
@@ -72,9 +72,9 @@ class TestContainerForEachSpec extends BaseSpec[TestContainerForEach] {
     }
     verify(container, times(0)).beforeTest(any())
     verify(container).start()
-    verify(spec).afterStart()
+    verify(spec).afterContainersStart(any())
     verify(container, times(0)).afterTest(any(), any())
-    verify(spec).beforeStop()
+    verify(spec).beforeContainersStop(any())
     verify(container).stop()
   }
 
@@ -116,7 +116,8 @@ object TestContainerForEachSpec {
 
     override val containerDef: ContainerDef = contDef
 
-    override def afterStart(): Unit = throw new RuntimeException("something wrong in afterStart()")
+    override def afterContainersStart(containers: Containers): Unit =
+      throw new RuntimeException("something wrong in afterContainersStart()")
 
     it should "test1" in {
       testBody

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/scalatest/TestContainersForAllSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/scalatest/TestContainersForAllSpec.scala
@@ -80,7 +80,7 @@ class TestContainersForAllSpec extends BaseSpec[TestContainersForAll] {
     verify(container2).stop()
   }
 
-  it should "call afterStart() and beforeStop()" in {
+  it should "call afterContainersStart() and beforeContainersStop()" in {
     val container1 = mock[SampleJavaContainer]
     val container2 = mock[SampleJavaContainer]
 
@@ -91,13 +91,13 @@ class TestContainersForAllSpec extends BaseSpec[TestContainersForAll] {
     val spec = new MultipleTestsSpec({
       assert(1 == 1)
     }, container1, container2) {
-      override def afterStart(): Unit = {
-        super.afterStart()
+      override def afterContainersStart(containers: Containers): Unit = {
+        super.afterContainersStart(containers)
         afterStartCalled = true
       }
 
-      override def beforeStop(): Unit = {
-        super.beforeStop()
+      override def beforeContainersStop(containers: Containers): Unit = {
+        super.beforeContainersStop(containers)
         beforeStopCalled = true
       }
     }
@@ -107,7 +107,7 @@ class TestContainersForAllSpec extends BaseSpec[TestContainersForAll] {
     assert(res.succeeds() && afterStartCalled && beforeStopCalled)
   }
 
-  it should "call beforeStop() and stop container if error thrown in afterStart()" in {
+  it should "call beforeContainersStop() and stop container if error thrown in afterContainersStart()" in {
     val container1 = mock[SampleJavaContainer]
     val container2 = mock[SampleJavaContainer]
 
@@ -117,13 +117,13 @@ class TestContainersForAllSpec extends BaseSpec[TestContainersForAll] {
     val spec = new MultipleTestsSpec({
       assert(1 == 1)
     }, container1, container2) {
-      override def afterStart(): Unit = {
+      override def afterContainersStart(containers: Containers): Unit = {
         afterStartCalled = true
         throw new RuntimeException("Test")
       }
 
-      override def beforeStop(): Unit = {
-        super.beforeStop()
+      override def beforeContainersStop(containers: Containers): Unit = {
+        super.beforeContainersStop(containers)
         beforeStopCalled = true
       }
     }

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/scalatest/TestContainersForEachSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/scalatest/TestContainersForEachSpec.scala
@@ -80,7 +80,7 @@ class TestContainersForEachSpec extends BaseSpec[TestContainersForEach] {
     verify(container2, times(2)).stop()
   }
 
-  it should "call afterStart() and beforeStop()" in {
+  it should "call afterContainersStart() and beforeContainersStop()" in {
     val container1 = mock[SampleJavaContainer]
     val container2 = mock[SampleJavaContainer]
 
@@ -91,13 +91,13 @@ class TestContainersForEachSpec extends BaseSpec[TestContainersForEach] {
     val spec = new MultipleTestsSpec({
       assert(1 == 1)
     }, container1, container2) {
-      override def afterStart(): Unit = {
-        super.afterStart()
+      override def afterContainersStart(containers: Containers): Unit = {
+        super.afterContainersStart(containers)
         afterStartCalled = true
       }
 
-      override def beforeStop(): Unit = {
-        super.beforeStop()
+      override def beforeContainersStop(containers: Containers): Unit = {
+        super.beforeContainersStop(containers)
         beforeStopCalled = true
       }
     }
@@ -107,7 +107,7 @@ class TestContainersForEachSpec extends BaseSpec[TestContainersForEach] {
     assert(res.succeeds() && afterStartCalled && beforeStopCalled)
   }
 
-  it should "call beforeStop() and stop container if error thrown in afterStart()" in {
+  it should "call beforeContainersStop() and stop container if error thrown in afterContainersStart()" in {
     val container1 = mock[SampleJavaContainer]
     val container2 = mock[SampleJavaContainer]
 
@@ -117,13 +117,13 @@ class TestContainersForEachSpec extends BaseSpec[TestContainersForEach] {
     val spec = new MultipleTestsSpec({
       assert(1 == 1)
     }, container1, container2) {
-      override def afterStart(): Unit = {
+      override def afterContainersStart(containers: Containers): Unit = {
         afterStartCalled = true
         throw new RuntimeException("Test")
       }
 
-      override def beforeStop(): Unit = {
-        super.beforeStop()
+      override def beforeContainersStop(containers: Containers): Unit = {
+        super.beforeContainersStop(containers)
         beforeStopCalled = true
       }
     }


### PR DESCRIPTION
I tried to use a new API in the real codebase and faced a few problems. With this pull request I fixed them.
* Changed signature of `def withContainers(runTest: Containers => Unit): Unit` to `def withContainers[A](runTest: Containers => A): A`. This improvement makes `withContainers` function usable in `Async*` specs and in user-defined utility wrappers around `withContainers`.
* Also, I tried to use `afterStart` and `beforeStop` method and realized, that they are useless without containers inside. So, I added `containers: Containers` argument to both these methods. Also, I renamed them to `afterContainersStart` and `beforeContainersStop`, because these names are a lot more suitable for these methods after my changes.

I think these fixes should be released with 0.34.1 version. API was marked as experimental, so I don't think that we need to worry about backward compatibility. Also, we still didn't present it widely :)