### PR TITLE
Remove dockerImageName for OracleContainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Here is the full list of the currently available modules:
 * `testcontainers-scala-cassandra` — module with the Cassandra container.
 * `testcontainers-scala-kafka` — module with the Kafka container.
 * `testcontainers-scala-vault` — module with the Vault container.
+* `testcontainers-scala-oracle-xe` — module with the Oracle container.
 
 ## Container types
 
@@ -406,6 +407,9 @@ object NginxContainer {
 If you have any questions or difficulties feel free to ask it in our [slack channel](https://testcontainers.slack.com/messages/CAFK4GL85).
 
 ## Release notes
+
+* **0.34.2**
+    * New `OracleContainer`. It is in the `testcontainers-scala-oracle-xe` package.
 
 * **0.34.1**
     * New API improvements:

--- a/modules/oracle/src/main/scala/com/dimafeng/testcontainers/OracleContainer.scala
+++ b/modules/oracle/src/main/scala/com/dimafeng/testcontainers/OracleContainer.scala
@@ -2,8 +2,14 @@ package com.dimafeng.testcontainers
 
 import org.testcontainers.containers.{OracleContainer => JavaOracleContainer}
 
+/**
+  * @param dockerImageName Oracle doesn't have any official distribution of XE,
+  *                        so we don't provide any default `dockerImageName`.
+  *                        You either need to build your own image or use some third-party image,
+  *                        for instance "oracleinanutshell/oracle-xe-11g".
+  */
 case class OracleContainer(
-  dockerImageName: String = OracleContainer.defaultDockerImageName,
+  dockerImageName: String,
   oraUsername: String = OracleContainer.defaultUsername,
   oraPassword: String = OracleContainer.defaultPassword,
   containerSharedMemory: Long = OracleContainer.defaultSharedMemory
@@ -28,13 +34,12 @@ case class OracleContainer(
 
 object OracleContainer {
 
-  val defaultDockerImageName = s"oracleinanutshell/oracle-xe-11g"
   val defaultDatabaseName = "xe"
   val defaultUsername = "system"
   val defaultPassword = "oracle"
   val defaultSharedMemory = 10240000000L //1 GB
 
-  case class Def(dockerImageName: String = defaultDockerImageName,
+  case class Def(dockerImageName: String,
                  username: String = defaultUsername,
                  password: String = defaultPassword,
                  containerSharedMemory: Long = defaultSharedMemory)

--- a/modules/oracle/src/test/scala/com/dimafeng/testcontainers/OracleSpec.scala
+++ b/modules/oracle/src/test/scala/com/dimafeng/testcontainers/OracleSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.FlatSpec
 
 class OracleSpec extends FlatSpec with ForAllTestContainer {
 
-  override val container: OracleContainer = new OracleContainer()
+  override val container: OracleContainer = OracleContainer("oracleinanutshell/oracle-xe-11g")
 
   "Oracle container" should "be started" in {
     Class.forName(container.driverClassName)


### PR DESCRIPTION
Removed `dockerImageName` from the `OracleContainer`, because oracle doesn't provide any official image. More details here: https://testcontainers.slack.com/archives/C9EJ7TVT7/p1576740487005000

Also, I added changelog for 0.34.2.