### PR TITLE
Fix ClickHouseContainer: remove password parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,9 @@ If you have any questions or difficulties feel free to ask it in our [slack chan
 
 ## Release notes
 
+* **0.35.3**
+    * Removed `dbPassword` parameter from the `ClickHouseContainer`. Looks like this parameter was added accidentally (java container doesn't support it).
+
 * **0.35.2**
     * testcontainers-java updated to 1.12.5.
     * Added methods to the `SingleContainer`:

--- a/modules/clickhouse/src/main/scala/com/dimafeng/testcontainers/ClickHouseContainer.scala
+++ b/modules/clickhouse/src/main/scala/com/dimafeng/testcontainers/ClickHouseContainer.scala
@@ -3,15 +3,10 @@ package com.dimafeng.testcontainers
 import org.testcontainers.containers.{ClickHouseContainer => JavaClickHouseContainer}
 
 case class ClickHouseContainer(
-  dockerImageName: String = ClickHouseContainer.defaultDockerImageName,
-  dbPassword: String = ClickHouseContainer.defaultPassword
+  dockerImageName: String = ClickHouseContainer.defaultDockerImageName
 ) extends SingleContainer[JavaClickHouseContainer] with JdbcDatabaseContainer {
 
-  override val container: JavaClickHouseContainer = {
-    val c = new JavaClickHouseContainer(dockerImageName)
-    c.withPassword(dbPassword)
-    c
-  }
+  override val container: JavaClickHouseContainer = new JavaClickHouseContainer(dockerImageName)
 
   def testQueryString: String = container.getTestQueryString
 }
@@ -19,19 +14,16 @@ case class ClickHouseContainer(
 object ClickHouseContainer {
 
   val defaultDockerImageName = s"${JavaClickHouseContainer.IMAGE}:${JavaClickHouseContainer.DEFAULT_TAG}"
-  val defaultPassword = ""
 
   case class Def(
-    dockerImageName: String = ClickHouseContainer.defaultDockerImageName,
-    password: String = ClickHouseContainer.defaultPassword
+    dockerImageName: String = ClickHouseContainer.defaultDockerImageName
   ) extends ContainerDef {
 
     override type Container = ClickHouseContainer
 
     override def createContainer(): ClickHouseContainer = {
       new ClickHouseContainer(
-        dockerImageName = dockerImageName,
-        dbPassword = password
+        dockerImageName = dockerImageName
       )
     }
   }

--- a/modules/clickhouse/src/test/scala/com/dimafeng/testcontainers/ClickHouseContainerSpec.scala
+++ b/modules/clickhouse/src/test/scala/com/dimafeng/testcontainers/ClickHouseContainerSpec.scala
@@ -1,0 +1,13 @@
+package com.dimafeng.testcontainers
+
+import com.dimafeng.testcontainers.scalatest.TestContainerForAll
+import org.scalatest.FlatSpec
+
+class ClickHouseContainerSpec extends FlatSpec with TestContainerForAll {
+
+  override val containerDef: ClickHouseContainer.Def = ClickHouseContainer.Def()
+
+  "ClickHouseContainer" should "work" in withContainers { clickHouseContainer =>
+    assert(clickHouseContainer.containerIpAddress.nonEmpty)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -128,6 +128,8 @@ object Dependencies {
   val moduleClickhouse = Def.setting(
     COMPILE(
       "org.testcontainers" % "clickhouse" % testcontainersVersion
+    ) ++ TEST(
+      "ru.yandex.clickhouse" % "clickhouse-jdbc" % "0.2.4",
     )
   )
 


### PR DESCRIPTION
Fix for #111 

Looks like `dbPassword` parameter was added accidentally. Java container doesn't support it.