### PR TITLE
Updating testcontainers-java to 1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Here is the full list of the currently available modules:
 * `testcontainers-scala-pulsar` — module with the Pulsar container.
 * `testcontainers-scala-rabbitmq` — module with the RabbitMQ container.
 * `testcontainers-scala-toxiproxy` — module with the ToxiProxy container.
+* `testcontainers-scala-orientdb` — module with the OrientDB container.
+* `testcontainers-scala-presto` — module with the Presto container.
 
 Most of the modules are just proxies to the testcontainers-java modules and behave exactly like java containers.
 You can find documentation about them in the [testcontainers-java docs pages](https://www.testcontainers.org/).
@@ -427,7 +429,12 @@ If you have any questions or difficulties feel free to ask it in our [slack chan
 
 ## Release notes
 
-* **0.35.3**
+* **0.36.0**
+    * testcontainers-java updated to 1.13.0:
+        * Added `OrientDBContainer`.
+        * Added `PrestoContainer`.
+        * Added `DockerComposeContainer.getContainerByServiceName` method.
+    * Change module dependencies for container modules. They now depend on the core module instead of scalatest module.
     * Removed `dbPassword` parameter from the `ClickHouseContainer`. Looks like this parameter was added accidentally (java container doesn't support it).
 
 * **0.35.2**

--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,8 @@ lazy val root = (project in file("."))
     modulePulsar,
     moduleRabbitmq,
     moduleToxiproxy,
+    moduleOrientdb,
+    modulePresto,
     allOld
   )
   .settings(noPublishSettings)
@@ -206,7 +208,7 @@ lazy val scalatestSelenium = (project in file("test-framework/scalatest-selenium
   )
 
 lazy val jdbc = (project in file("modules/jdbc"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-jdbc",
@@ -214,7 +216,7 @@ lazy val jdbc = (project in file("modules/jdbc"))
   )
 
 lazy val moduleMysql = (project in file("modules/mysql"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided", jdbc)
+  .dependsOn(core % "compile->compile;test->test;provided->provided", scalatest % "test->test", jdbc)
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-mysql",
@@ -222,7 +224,7 @@ lazy val moduleMysql = (project in file("modules/mysql"))
   )
 
 lazy val moduleNeo4j = (project in file("modules/neo4j"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided", scalatest % "test->test")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-neo4j",
@@ -230,7 +232,7 @@ lazy val moduleNeo4j = (project in file("modules/neo4j"))
   )
 
 lazy val modulePostgres = (project in file("modules/postgres"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided", jdbc)
+  .dependsOn(core % "compile->compile;test->test;provided->provided", scalatest % "test->test", jdbc)
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-postgresql",
@@ -238,7 +240,7 @@ lazy val modulePostgres = (project in file("modules/postgres"))
   )
 
 lazy val moduleOracle = (project in file("modules/oracle"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided", jdbc)
+  .dependsOn(core % "compile->compile;test->test;provided->provided", scalatest % "test->test", jdbc)
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-oracle-xe",
@@ -246,7 +248,7 @@ lazy val moduleOracle = (project in file("modules/oracle"))
   )
 
 lazy val moduleCassandra = (project in file("modules/cassandra"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided", scalatest % "test->test")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-cassandra",
@@ -254,7 +256,7 @@ lazy val moduleCassandra = (project in file("modules/cassandra"))
   )
 
 lazy val moduleKafka = (project in file("modules/kafka"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided", scalatest % "test->test")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-kafka",
@@ -262,7 +264,7 @@ lazy val moduleKafka = (project in file("modules/kafka"))
   )
 
 lazy val moduleVault = (project in file("modules/vault"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided", scalatest % "test->test")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-vault",
@@ -270,7 +272,7 @@ lazy val moduleVault = (project in file("modules/vault"))
   )
 
 lazy val moduleMssqlserver = (project in file("modules/mssqlserver"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided", jdbc)
+  .dependsOn(core % "compile->compile;test->test;provided->provided", jdbc)
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-mssqlserver",
@@ -278,7 +280,7 @@ lazy val moduleMssqlserver = (project in file("modules/mssqlserver"))
   )
 
 lazy val moduleClickhouse = (project in file("modules/clickhouse"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided", jdbc)
+  .dependsOn(scalatest % "test->test", jdbc)
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-clickhouse",
@@ -286,7 +288,7 @@ lazy val moduleClickhouse = (project in file("modules/clickhouse"))
   )
 
 lazy val moduleCockroachdb = (project in file("modules/cockroachdb"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided", jdbc)
+  .dependsOn(core % "compile->compile;test->test;provided->provided", jdbc)
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-cockroachdb",
@@ -294,7 +296,7 @@ lazy val moduleCockroachdb = (project in file("modules/cockroachdb"))
   )
 
 lazy val moduleCouchbase = (project in file("modules/couchbase"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-couchbase",
@@ -302,7 +304,7 @@ lazy val moduleCouchbase = (project in file("modules/couchbase"))
   )
 
 lazy val moduleDb2 = (project in file("modules/db2"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided", jdbc)
+  .dependsOn(core % "compile->compile;test->test;provided->provided", jdbc)
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-db2",
@@ -310,7 +312,7 @@ lazy val moduleDb2 = (project in file("modules/db2"))
   )
 
 lazy val moduleDynalite = (project in file("modules/dynalite"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-dynalite",
@@ -318,7 +320,7 @@ lazy val moduleDynalite = (project in file("modules/dynalite"))
   )
 
 lazy val moduleElasticsearch = (project in file("modules/elasticsearch"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-elasticsearch",
@@ -326,7 +328,7 @@ lazy val moduleElasticsearch = (project in file("modules/elasticsearch"))
   )
 
 lazy val moduleInfluxdb = (project in file("modules/influxdb"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-influxdb",
@@ -334,7 +336,7 @@ lazy val moduleInfluxdb = (project in file("modules/influxdb"))
   )
 
 lazy val moduleLocalstack = (project in file("modules/localstack"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-localstack",
@@ -342,7 +344,7 @@ lazy val moduleLocalstack = (project in file("modules/localstack"))
   )
 
 lazy val moduleMariadb = (project in file("modules/mariadb"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided", jdbc)
+  .dependsOn(core % "compile->compile;test->test;provided->provided", jdbc)
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-mariadb",
@@ -350,7 +352,7 @@ lazy val moduleMariadb = (project in file("modules/mariadb"))
   )
 
 lazy val moduleMockserver = (project in file("modules/mockserver"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-mockserver",
@@ -358,7 +360,7 @@ lazy val moduleMockserver = (project in file("modules/mockserver"))
   )
 
 lazy val moduleNginx = (project in file("modules/nginx"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-nginx",
@@ -366,7 +368,7 @@ lazy val moduleNginx = (project in file("modules/nginx"))
   )
 
 lazy val modulePulsar = (project in file("modules/pulsar"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-pulsar",
@@ -374,7 +376,7 @@ lazy val modulePulsar = (project in file("modules/pulsar"))
   )
 
 lazy val moduleRabbitmq = (project in file("modules/rabbitmq"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-rabbitmq",
@@ -382,11 +384,27 @@ lazy val moduleRabbitmq = (project in file("modules/rabbitmq"))
   )
 
 lazy val moduleToxiproxy = (project in file("modules/toxiproxy"))
-  .dependsOn(scalatest % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-toxiproxy",
     libraryDependencies ++= Dependencies.moduleToxiproxy.value
+  )
+
+lazy val moduleOrientdb = (project in file("modules/orientdb"))
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
+  .settings(commonSettings: _*)
+  .settings(
+    name := "testcontainers-scala-orientdb",
+    libraryDependencies ++= Dependencies.moduleOrientdb.value
+  )
+
+lazy val modulePresto = (project in file("modules/presto"))
+  .dependsOn(core % "compile->compile;test->test;provided->provided", jdbc)
+  .settings(commonSettings: _*)
+  .settings(
+    name := "testcontainers-scala-presto",
+    libraryDependencies ++= Dependencies.modulePresto.value
   )
 
 lazy val microsite = (project in file("docs"))

--- a/core/src/main/scala/com/dimafeng/testcontainers/DockerComposeContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/DockerComposeContainer.scala
@@ -7,7 +7,7 @@ import java.util.function.Consumer
 import com.dimafeng.testcontainers.DockerComposeContainer.ComposeFile
 import org.testcontainers.containers.output.OutputFrame
 import org.testcontainers.containers.wait.strategy.{Wait, WaitStrategy}
-import org.testcontainers.containers.{DockerComposeContainer => JavaDockerComposeContainer}
+import org.testcontainers.containers.{ContainerState, DockerComposeContainer => JavaDockerComposeContainer}
 import org.testcontainers.utility.Base58
 
 import scala.collection.JavaConverters._
@@ -137,6 +137,11 @@ class DockerComposeContainer(composeFiles: ComposeFile,
   def getServiceHost(serviceName: String, servicePort: Int): String = container.getServiceHost(serviceName, servicePort)
 
   def getServicePort(serviceName: String, servicePort: Int): Int = container.getServicePort(serviceName, servicePort)
+
+  def getContainerByServiceName(serviceName: String): Option[ContainerState] = {
+    val res = container.getContainerByServiceName(serviceName)
+    if (res.isPresent) Some(res.get()) else None
+  }
 
   override def start(): Unit = container.start()
 

--- a/modules/mysql/src/test/scala/com/dimafeng/testcontainers/MysqlSpec.scala
+++ b/modules/mysql/src/test/scala/com/dimafeng/testcontainers/MysqlSpec.scala
@@ -2,10 +2,7 @@ package com.dimafeng.testcontainers
 
 import java.sql.DriverManager
 
-import com.dimafeng.testcontainers.{ForAllTestContainer, MySQLContainer}
-import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
-import org.scalatest.junit.JUnitRunner
 
 class MysqlSpec extends FlatSpec with ForAllTestContainer {
 

--- a/modules/orientdb/src/main/scala/com/dimafeng/testcontainers/OrientDBContainer.scala
+++ b/modules/orientdb/src/main/scala/com/dimafeng/testcontainers/OrientDBContainer.scala
@@ -1,0 +1,58 @@
+package com.dimafeng.testcontainers
+
+import com.orientechnologies.orient.core.db.{ODatabaseSession, OrientDB}
+import org.testcontainers.containers.{OrientDBContainer => JavaOrientDBContainer}
+
+case class OrientDBContainer(
+  dockerImageName: String = OrientDBContainer.defaultDockerImageName,
+  databaseName: String = OrientDBContainer.defaultDatabaseName,
+  serverPassword: String = OrientDBContainer.defaultServerPassword,
+  scriptPath: Option[String] = None
+) extends SingleContainer[JavaOrientDBContainer] {
+
+  override val container: JavaOrientDBContainer = {
+    val c = new JavaOrientDBContainer(dockerImageName)
+    c.withDatabaseName(databaseName)
+    c.withServerPassword(serverPassword)
+    scriptPath.foreach(c.withScriptPath)
+    c
+  }
+
+  def testQueryString: String = container.getTestQueryString
+
+  def orientDB: OrientDB = container.getOrientDB
+
+  def serverUrl: String = container.getServerUrl
+
+  def dbUrl: String = container.getDbUrl
+
+  def session: ODatabaseSession = container.getSession
+
+  def session(username: String, password: String): ODatabaseSession = container.getSession(username, password)
+}
+
+object OrientDBContainer {
+
+  val defaultDockerImageName = "orientdb:3.0.24-tp3"
+  val defaultDatabaseName = "testcontainers"
+  val defaultServerPassword = "root"
+
+  case class Def(
+    dockerImageName: String = OrientDBContainer.defaultDockerImageName,
+    databaseName: String = OrientDBContainer.defaultDatabaseName,
+    serverPassword: String = OrientDBContainer.defaultServerPassword,
+    scriptPath: Option[String] = None
+  ) extends ContainerDef {
+
+    override type Container = OrientDBContainer
+
+    override def createContainer(): OrientDBContainer = {
+      new OrientDBContainer(
+        dockerImageName,
+        databaseName,
+        serverPassword,
+        scriptPath
+      )
+    }
+  }
+}

--- a/modules/presto/src/main/scala/com/dimafeng/testcontainers/PrestoContainer.scala
+++ b/modules/presto/src/main/scala/com/dimafeng/testcontainers/PrestoContainer.scala
@@ -1,0 +1,47 @@
+package com.dimafeng.testcontainers
+
+import java.sql.Connection
+
+import org.testcontainers.containers.{PrestoContainer => JavaPrestoContainer}
+
+case class PrestoContainer(
+  dockerImageName: String = PrestoContainer.defaultDockerImageName,
+  dbUsername: String = PrestoContainer.defaultDbUsername,
+  dbName: String = PrestoContainer.defaultDbName
+) extends SingleContainer[JavaPrestoContainer[_]] with JdbcDatabaseContainer {
+
+  override val container: JavaPrestoContainer[_] = {
+    val c = new JavaPrestoContainer(dockerImageName)
+    c.withUsername(dbUsername)
+    c.withDatabaseName(dbName)
+    c
+  }
+
+  def testQueryString: String = container.getTestQueryString
+
+  def createConnection: Connection = container.createConnection()
+}
+
+object PrestoContainer {
+
+  val defaultDockerImageName = s"${JavaPrestoContainer.IMAGE}:${JavaPrestoContainer.DEFAULT_TAG}"
+  val defaultDbUsername = "test"
+  val defaultDbName = ""
+
+  case class Def(
+    dockerImageName: String = PrestoContainer.defaultDockerImageName,
+    dbUsername: String = PrestoContainer.defaultDbUsername,
+    dbName: String = PrestoContainer.defaultDbName
+  ) extends ContainerDef {
+
+    override type Container = PrestoContainer
+
+    override def createContainer(): PrestoContainer = {
+      new PrestoContainer(
+        dockerImageName,
+        dbUsername,
+        dbName
+      )
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     scope.map(s => modules.map(_ % s)).getOrElse(modules)
   }
 
-  private val testcontainersVersion = "1.12.5"
+  private val testcontainersVersion = "1.13.0"
   private val seleniumVersion = "2.53.1"
   private val slf4jVersion = "1.7.25"
   private val scalaTestVersion = "3.0.8"
@@ -214,6 +214,18 @@ object Dependencies {
   val moduleToxiproxy = Def.setting(
     COMPILE(
       "org.testcontainers" % "toxiproxy" % testcontainersVersion
+    )
+  )
+
+  val moduleOrientdb = Def.setting(
+    COMPILE(
+      "org.testcontainers" % "orientdb" % testcontainersVersion
+    )
+  )
+
+  val modulePresto = Def.setting(
+    COMPILE(
+      "org.testcontainers" % "presto" % testcontainersVersion
     )
   )
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.35.3-SNAPSHOT"
+version in ThisBuild := "0.36.0-SNAPSHOT"


### PR DESCRIPTION
* testcontainers-java updated to 1.13.0.
    * Added `OrientDBContainer`.
    * Added `PrestoContainer`.
    * Added `DockerComposeContainer.getContainerByServiceName method`.
* Change module dependencies for container modules. They now depend on the core module and not depend on the scalatest module.
* Up version to the 0.36.0.