### PR TITLE
Image name bug fix

### DIFF
--- a/modules/rabbitmq/src/main/scala/com/dimafeng/testcontainers/RabbitMQContainer.scala
+++ b/modules/rabbitmq/src/main/scala/com/dimafeng/testcontainers/RabbitMQContainer.scala
@@ -26,7 +26,7 @@ case class RabbitMQContainer(
   import scala.collection.JavaConverters._
 
   override val container: JavaRabbitMQContainer = {
-    val c = new JavaRabbitMQContainer()
+    val c = new JavaRabbitMQContainer(dockerImageName)
 
     c.withAdminPassword(adminPassword)
 


### PR DESCRIPTION
Passing through image name to java container constructor