### PR TITLE
Added method to get the jdbc url with the ip(Postgres)

### DIFF
--- a/modules/postgres/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala
+++ b/modules/postgres/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala
@@ -1,6 +1,9 @@
 package com.dimafeng.testcontainers
 
 import org.testcontainers.containers.{PostgreSQLContainer => JavaPostgreSQLContainer}
+import scala.collection.JavaConverters._
+import org.testcontainers.containers.{PostgreSQLContainer => OTCPostgreSQLContainer}
+
 
 class PostgreSQLContainer(
   dockerImageNameOverride: Option[String] = None,
@@ -9,6 +12,13 @@ class PostgreSQLContainer(
   pgPassword: Option[String] = None,
   mountPostgresDataToTmpfs: Boolean = false
 ) extends SingleContainer[JavaPostgreSQLContainer[_]] with JdbcDatabaseContainer {
+
+  def jdbcUrlWithIp: String =  {
+
+    val ip = container.getContainerInfo.getNetworkSettings.getNetworks.asScala.values.head.getIpAddress
+    s"jdbc:postgresql://$ip:${OTCPostgreSQLContainer.POSTGRESQL_PORT}/${databaseName}"
+
+  }
 
   override val container: JavaPostgreSQLContainer[_] = dockerImageNameOverride match {
 


### PR DESCRIPTION
Right now with Postgres, the JDBC url generated is using localhost, but in my use case it's not enough.
In some tests I used a container that needs the Postgres connection, using  the `PostgreSQLContainer.jdbcUrl` is not working because the url is using localhost.

My tests defined the containers with something like this:
```
lazy val postgresContainer: PostgreSQLContainer =
    PostgreSQLContainer(databaseName = s"user-${Random.nextInt(5)}")

lazy val myCustomContainer: GenericContainer = GenericContainer(
    dockerImage = "my-service:latest",
    exposedPorts = Seq(8080),
    waitStrategy = Wait.forHttp("/health").forStatusCode(204),
    env = Map(
      "POSTGRES_USER" -> postgresContainer.username,
      "POSTGRES_PASSWORD" -> postgresContainer.password,
      "POSTGRES_URL" -> postgresContainer.jdbcUrl
    )
  )
 override val container: MultipleContainers =
    MultipleContainers(LazyContainer(postgresContainer), LazyContainer(userApiContainer))

```
As a workaround I used basically the method that I defined in this PR, would be useful from my point of view if this possibility will be present directly in the Postgres container itself.


