### PR TITLE
Fix 0.38.0 regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,17 @@ If you have any questions or difficulties feel free to ask it in our [slack chan
 
 ## Release notes
 
+* **0.38.1**
+    * Fixed class cast exception in the next containers:
+        * InfluxDBContainer
+        * MariaDBContainer
+        * MSSQLServerContainer
+        * MySQLContainer
+        * NginxContainer
+        * PostgreSQLContainer
+        * PrestoContainer
+        * VaultContainer
+
 * **0.38.0**
     * testcontainers-java updated to 1.14.3:
         * Added `MongoDBContainer`.

--- a/modules/influxdb/src/main/scala/com/dimafeng/testcontainers/InfluxDBContainer.scala
+++ b/modules/influxdb/src/main/scala/com/dimafeng/testcontainers/InfluxDBContainer.scala
@@ -14,7 +14,7 @@ case class InfluxDBContainer(
 ) extends SingleContainer[JavaInfluxDBContainer[_]] {
 
   override val container: JavaInfluxDBContainer[_] = {
-    val c = new JavaInfluxDBContainer(tag)
+    val c: JavaInfluxDBContainer[_] = new JavaInfluxDBContainer(tag)
     c.withDatabase(database)
     c.withAdmin(admin)
     c.withAdminPassword(adminPassword)

--- a/modules/mariadb/src/main/scala/com/dimafeng/testcontainers/MariaDBContainer.scala
+++ b/modules/mariadb/src/main/scala/com/dimafeng/testcontainers/MariaDBContainer.scala
@@ -13,7 +13,7 @@ case class MariaDBContainer(
 ) extends SingleContainer[JavaMariaDBContainer[_]] with JdbcDatabaseContainer {
 
   override val container: JavaMariaDBContainer[_] = {
-    val c = new JavaMariaDBContainer(dockerImageName)
+    val c: JavaMariaDBContainer[_] = new JavaMariaDBContainer(dockerImageName)
 
     c.withDatabaseName(dbName)
     c.withUsername(dbUsername)

--- a/modules/mssqlserver/src/main/scala/com/dimafeng/testcontainers/MSSQLServerContainer.scala
+++ b/modules/mssqlserver/src/main/scala/com/dimafeng/testcontainers/MSSQLServerContainer.scala
@@ -12,7 +12,7 @@ case class MSSQLServerContainer(
 ) extends SingleContainer[JavaMSSQLServerContainer[_]] with JdbcDatabaseContainer {
 
   override val container: JavaMSSQLServerContainer[_] = {
-    val c = new JavaMSSQLServerContainer(dockerImageName)
+    val c: JavaMSSQLServerContainer[_] = new JavaMSSQLServerContainer(dockerImageName)
 
     c.withPassword(dbPassword)
     urlParams.foreach { case (key, value) =>

--- a/modules/mysql/src/main/scala/com/dimafeng/testcontainers/MySQLContainer.scala
+++ b/modules/mysql/src/main/scala/com/dimafeng/testcontainers/MySQLContainer.scala
@@ -13,7 +13,7 @@ class MySQLContainer(
 ) extends SingleContainer[JavaMySQLContainer[_]] with JdbcDatabaseContainer {
 
   override val container: JavaMySQLContainer[_] = {
-    val c = mysqlImageVersion
+    val c: JavaMySQLContainer[_] = mysqlImageVersion
       .map(new JavaMySQLContainer(_))
       .getOrElse(new JavaMySQLContainer(MySQLContainer.DEFAULT_MYSQL_VERSION))
 

--- a/modules/nginx/src/main/scala/com/dimafeng/testcontainers/NginxContainer.scala
+++ b/modules/nginx/src/main/scala/com/dimafeng/testcontainers/NginxContainer.scala
@@ -9,7 +9,7 @@ case class NginxContainer(
 ) extends SingleContainer[JavaNginxContainer[_]] {
 
   override val container: JavaNginxContainer[_] = {
-    val c = new JavaNginxContainer()
+    val c: JavaNginxContainer[_] = new JavaNginxContainer()
     customContent.foreach(c.withCustomContent)
     c
   }

--- a/modules/postgres/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala
+++ b/modules/postgres/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala
@@ -13,16 +13,16 @@ class PostgreSQLContainer(
 ) extends SingleContainer[JavaPostgreSQLContainer[_]] with JdbcDatabaseContainer {
 
   override val container: JavaPostgreSQLContainer[_] = {
-    val c = dockerImageNameOverride match {
+    val c: JavaPostgreSQLContainer[_] = dockerImageNameOverride match {
       case Some(imageNameOverride) =>
         new JavaPostgreSQLContainer(imageNameOverride)
       case None =>
         new JavaPostgreSQLContainer()
     }
 
-    databaseName.map(c.withDatabaseName)
-    pgUsername.map(c.withUsername)
-    pgPassword.map(c.withPassword)
+    databaseName.foreach(c.withDatabaseName)
+    pgUsername.foreach(c.withUsername)
+    pgPassword.foreach(c.withPassword)
 
     // as suggested in https://github.com/testcontainers/testcontainers-java/issues/1256
     // mounting the postgres data directory to an in-memory docker volume (https://docs.docker.com/storage/tmpfs/)

--- a/modules/presto/src/main/scala/com/dimafeng/testcontainers/PrestoContainer.scala
+++ b/modules/presto/src/main/scala/com/dimafeng/testcontainers/PrestoContainer.scala
@@ -12,7 +12,7 @@ case class PrestoContainer(
 ) extends SingleContainer[JavaPrestoContainer[_]] with JdbcDatabaseContainer {
 
   override val container: JavaPrestoContainer[_] = {
-    val c = new JavaPrestoContainer(dockerImageName)
+    val c: JavaPrestoContainer[_] = new JavaPrestoContainer(dockerImageName)
     c.withUsername(dbUsername)
     c.withDatabaseName(dbName)
     commonJdbcParams.applyTo(c)

--- a/modules/vault/src/main/scala/com/dimafeng/testcontainers/VaultContainer.scala
+++ b/modules/vault/src/main/scala/com/dimafeng/testcontainers/VaultContainer.scala
@@ -7,7 +7,7 @@ class VaultContainer(dockerImageNameOverride: Option[String] = None,
                      @deprecated vaultPort: Option[Int] = None,
                      secrets: Option[VaultContainer.Secrets] = None) extends SingleContainer[JavaVaultContainer[_]] {
 
-  val vaultContainer: JavaVaultContainer[Nothing] = {
+  val vaultContainer: JavaVaultContainer[_] = {
     if (dockerImageNameOverride.isEmpty) {
       new JavaVaultContainer()
     } else {


### PR DESCRIPTION
Fix for #127

Scala compiler infers types of containers with `SELF` type parameter to `Foo[Nothing]` instead of `Foo[_]` and it leads to a class cast exception. I added explicit signatures and the issue is gone. Also, I fixed this issue in all other containers with `SELF` type parameter in the signature.

These issues could have been avoided if we had tests for at least a happy path for all containers.