### PR TITLE
fix default image-tag name in MongoDBContainer 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -420,7 +420,7 @@ lazy val modulePresto = (project in file("modules/presto"))
   )
 
 lazy val moduleMongodb = (project in file("modules/mongodb"))
-  .dependsOn(core % "compile->compile;test->test;provided->provided", jdbc)
+  .dependsOn(core % "compile->compile;test->test;provided->provided", jdbc, scalatest % "test->test")
   .settings(commonSettings: _*)
   .settings(
     name := "testcontainers-scala-mongodb",

--- a/modules/mongodb/src/main/scala/com/dimafeng/testcontainers/MongoDBContainer.scala
+++ b/modules/mongodb/src/main/scala/com/dimafeng/testcontainers/MongoDBContainer.scala
@@ -3,24 +3,27 @@ package com.dimafeng.testcontainers
 import org.testcontainers.containers.{MongoDBContainer => JavaMongoDBContainer}
 
 case class MongoDBContainer(
-  tag: String = MongoDBContainer.defaultTag
+  tag: Option[String] = None
 ) extends SingleContainer[JavaMongoDBContainer] {
 
-  override val container: JavaMongoDBContainer = new JavaMongoDBContainer(tag)
+  override val container: JavaMongoDBContainer = tag match {
+    case Some(tag) => new JavaMongoDBContainer(tag)
+    case None      => new JavaMongoDBContainer()
+  }
 
   def replicaSetUrl: String = container.getReplicaSetUrl
 }
 
 object MongoDBContainer {
 
-  val defaultTag = "4.0.10"
+  def apply(tag: String): MongoDBContainer = new MongoDBContainer(Option(tag))
 
   case class Def(
-    tag: String = MongoDBContainer.defaultTag
+    tag: String = null
   ) extends ContainerDef {
 
     override type Container = MongoDBContainer
 
-    override def createContainer(): MongoDBContainer = new MongoDBContainer(tag)
+    override def createContainer(): MongoDBContainer = new MongoDBContainer(Option(tag))
   }
 }

--- a/modules/mongodb/src/test/scala/com/dimafeng/testcontainers/integration/MongoSpec.scala
+++ b/modules/mongodb/src/test/scala/com/dimafeng/testcontainers/integration/MongoSpec.scala
@@ -1,0 +1,23 @@
+package com.dimafeng.testcontainers.integration
+
+import com.dimafeng.testcontainers.{Container, ForAllTestContainer, MongoDBContainer, MultipleContainers}
+import org.scalatest.{FlatSpec, Matchers}
+
+class MongoSpec extends FlatSpec with ForAllTestContainer with Matchers {
+
+  private val mongoDefault = MongoDBContainer()
+  private val mongo = MongoDBContainer("mongo:4.0.10")
+
+  override val container: Container = MultipleContainers(
+    mongoDefault, mongo
+  )
+
+  "Default Mongo container" should "be started" in {
+    assert(mongoDefault.replicaSetUrl.nonEmpty)
+  }
+
+  "Custom image Mongo container" should "be started" in {
+    assert(mongo.replicaSetUrl.nonEmpty)
+  }
+
+}


### PR DESCRIPTION
Hi, in this PR i fixed an issue when creating a `MongoDBContainer` without a specific tag.  It was crashing because the default tag was `4.0.10` instead of `mongo:4.0.10`, this was causing an exception downloading the (wrong) container image.
I fixed it removing the default tag in the `MongoDBContainer` class and delegating it to the underlying java container.
In addition i refactored the class to be more in line with the other modules and added some tests.