### PR TITLE
Don't set SolrContainer properties if not specified to avoid IllegalArgumentException

### DIFF
--- a/modules/solr/src/main/scala/com/dimafeng/testcontainers/SolrContainer.scala
+++ b/modules/solr/src/main/scala/com/dimafeng/testcontainers/SolrContainer.scala
@@ -18,8 +18,12 @@ case class SolrContainer(
 
     c.withZookeeper(zookeeper)
     c.withCollection(collectionName)
-    c.withConfiguration(configurationName, configuration)
-    c.withSchema(schema)
+    if (configurationName != null || configuration != null) {
+      c.withConfiguration(configurationName, configuration)
+    }
+    if (schema != null) {
+      c.withSchema(schema)
+    }
 
     c
   }


### PR DESCRIPTION
Some of `SolrContainer`'s properties can be omitted but in the current implementation, `null` is given for some properties if we don't specify and it causes `IllegalArgumentException` in the Java implementation of `SolrContainer`.

For example:
https://github.com/testcontainers/testcontainers-java/blob/53932d9988e8e09db45c8ccea0f39d0da7a24dc5/modules/solr/src/main/java/org/testcontainers/containers/SolrContainer.java#L59-L61

It would be better to skip to set if they are not specified explicitly.