### PR TITLE
add localstack container for using amazon java sdk v2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,7 @@ lazy val root = (project in file("."))
     moduleElasticsearch,
     moduleInfluxdb,
     moduleLocalstack,
+    moduleLocalstackV2,
     moduleMariadb,
     moduleMockserver,
     moduleNginx,
@@ -353,6 +354,14 @@ lazy val moduleLocalstack = (project in file("modules/localstack"))
   .settings(
     name := "testcontainers-scala-localstack",
     libraryDependencies ++= Dependencies.moduleLocalstack.value
+  )
+
+lazy val moduleLocalstackV2 = (project in file("modules/localstackV2"))
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
+  .settings(commonSettings: _*)
+  .settings(
+    name := "testcontainers-scala-localstack-v2",
+    libraryDependencies ++= Dependencies.moduleLocalstackV2.value
   )
 
 lazy val moduleMariadb = (project in file("modules/mariadb"))

--- a/modules/localstackV2/src/main/scala/com/dimafeng/testcontainers/LocalStackV2Container.scala
+++ b/modules/localstackV2/src/main/scala/com/dimafeng/testcontainers/LocalStackV2Container.scala
@@ -1,0 +1,51 @@
+package com.dimafeng.testcontainers
+
+import java.net.URI
+
+import org.testcontainers.containers.localstack.{LocalStackContainer => JavaLocalStackContainer}
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+
+case class LocalStackV2Container(
+  tag: String = LocalStackV2Container.defaultTag,
+  services: Seq[LocalStackV2Container.Service] = Seq.empty
+) extends SingleContainer[JavaLocalStackContainer] {
+
+  override val container: JavaLocalStackContainer = {
+    val c = new JavaLocalStackContainer(tag)
+    c.withServices(services: _*)
+    c
+  }
+
+  def endpointOverride(service: LocalStackV2Container.Service): URI =
+    container.getEndpointOverride(service)
+
+  def staticCredentialsProvider: StaticCredentialsProvider =
+    StaticCredentialsProvider.create(
+      AwsBasicCredentials.create(container.getAccessKey, container.getSecretKey)
+    )
+
+  def region: Region = Region.of(container.getRegion)
+}
+
+object LocalStackV2Container {
+
+  val defaultTag = "0.9.4"
+
+  type Service = JavaLocalStackContainer.Service
+
+  case class Def(
+                  tag: String = LocalStackV2Container.defaultTag,
+                  services: Seq[LocalStackV2Container.Service] = Seq.empty
+  ) extends ContainerDef {
+
+    override type Container = LocalStackV2Container
+
+    override def createContainer(): LocalStackV2Container = {
+      new LocalStackV2Container(
+        tag,
+        services
+      )
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,8 @@ object Dependencies {
   private val kafkaDriverVersion = "2.2.0"
   private val mockitoVersion = "3.3.3"
   private val restAssuredVersion = "4.0.0"
-  private val awsVersion = "1.11.479"
+  private val awsV1Version = "1.11.479"
+  private val awsV2Version = "2.15.7"
 
   val allOld = Def.setting(
     PROVIDED(
@@ -163,7 +164,7 @@ object Dependencies {
     COMPILE(
       "org.testcontainers" % "dynalite" % testcontainersVersion
     ) ++ PROVIDED(
-      "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion
+      "com.amazonaws" % "aws-java-sdk-dynamodb" % awsV1Version
     )
   )
 
@@ -185,7 +186,15 @@ object Dependencies {
     COMPILE(
       "org.testcontainers" % "localstack" % testcontainersVersion
     ) ++ PROVIDED(
-      "com.amazonaws" % "aws-java-sdk-s3" % awsVersion
+      "com.amazonaws" % "aws-java-sdk-s3" % awsV1Version
+    )
+  )
+
+  val moduleLocalstackV2 = Def.setting(
+    COMPILE(
+      "org.testcontainers" % "localstack" % testcontainersVersion
+    ) ++ PROVIDED(
+      "software.amazon.awssdk" % "s3" % awsV2Version
     )
   )
 


### PR DESCRIPTION
Addresses #135 by adding a separate module for using amazon's v2 java sdk with localstack containers. 

Usage example: 

```
S3Client.builder()
    .endpointOverride(container.endpointOverride(Service.S3))
    .credentialsProvider(container.staticCredentialsProvider)
    .region(container.region)
    .build()
```

Compared to the usage example for the underlying container with the v2 sdk https://www.testcontainers.org/modules/localstack/