### PR TITLE
Include fix for "Can not connect to Ryuk" on macOS with Docker for Ma…

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,10 @@ If you have any questions or difficulties feel free to ask it in our [slack chan
 
 ## Release notes
 
+* **0.38.6**
+    * testcontainers-java updated to 1.15.0:
+        * Include fix for "Can not connect to Ryuk" on macOS with Docker for Mac 2.4.0.0 (https://github.com/testcontainers/testcontainers-java/issues/3166)
+
 * **0.38.5**
     * Added `LocalStackV2Container`
 

--- a/core/src/main/scala/com/dimafeng/testcontainers/Container.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/Container.scala
@@ -104,8 +104,6 @@ abstract class SingleContainer[T <: JavaGenericContainer[_]] extends TestContain
 
   def dockerClient: DockerClient = container.getDockerClient
 
-  def dockerDaemonInfo: Info = container.getDockerDaemonInfo
-
   def logConsumers: Seq[Consumer[OutputFrame]] = container.getLogConsumers.asScala.toSeq
 
   def createContainerCmdModifiers: Set[Consumer[CreateContainerCmd]] = container.getCreateContainerCmdModifiers.asScala.toSet

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     scope.map(s => modules.map(_ % s)).getOrElse(modules)
   }
 
-  private val testcontainersVersion = "1.14.3"
+  private val testcontainersVersion = "1.15.0"
   private val seleniumVersion = "2.53.1"
   private val slf4jVersion = "1.7.25"
   private val scalaTestVersion = "3.0.8"

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/FixedHostPortContainerSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/FixedHostPortContainerSpec.scala
@@ -4,13 +4,13 @@ import java.net.URL
 
 import com.dimafeng.testcontainers.{FixedHostPortGenericContainer, ForAllTestContainer}
 import org.scalatest.FlatSpec
-import org.testcontainers.containers.wait.Wait
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
 
 import scala.io.Source
 
 class FixedHostPortContainerSpec extends FlatSpec with ForAllTestContainer {
   override val container = FixedHostPortGenericContainer("nginx:latest",
-    waitStrategy = Wait.forHttp("/"),
+    waitStrategy = new HttpWaitStrategy().forPath("/"),
     exposedHostPort = 8090,
     exposedContainerPort = 80
   )


### PR DESCRIPTION
Include fix for "Can not connect to Ryuk" on macOS with Docker for Mac 2.4.0.0 
(https://github.com/testcontainers/testcontainers-java/issues/3166)