### PR TITLE
Added a note about overriding container property

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ class MysqlSpec extends FlatSpec with ForAllTestContainer {
 }
 ```
 
+Be sure to override `container` with a `val` not a `def`, otherwise you will start a new container each 
+time you call `container` and this is likely to fail your tests.
+
 This spec has a clean mysql database instance for each of its test cases.
 
 ```scala


### PR DESCRIPTION
Overriding container with a `def` seems to be a common mistake since IntelliJ overrides with a `def` by default (I actually did it, see https://github.com/testcontainers/testcontainers-scala/issues/137). Hope this note will lead to less people experiencing it while not growing too much the "Quick Start" section.