### PR TITLE
Update JUnit dependency to 4.13.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   private val seleniumVersion = "2.53.1"
   private val slf4jVersion = "1.7.25"
   private val scalaTestVersion = "3.0.8"
-  private val junitVersion = "4.13"
+  private val junitVersion = "4.13.1"
   private val munitVersion = "0.7.4"
   private val mysqlConnectorVersion = "5.1.42"
   private val neo4jConnectorVersion = "4.0.0"


### PR DESCRIPTION
Junit 4.13 is vulnerable to information exposure, which got fixed in 4.13.1:

https://app.snyk.io/vuln/SNYK-JAVA-JUNIT-1017047

It's a low severity vulnerability, but the fix is easy.