### PR TITLE
Fix Scaladex listing by updating Sonatype info to correct git host

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ val commonSettings = Seq(
   },
   publishMavenStyle := true,
   sonatypeProfileName := "testcontainers-scala",
-  sonatypeProjectHosting := Some(GitLabHosting("testcontainers", "testcontainers-scala", "dimafeng@gmail.com")),
+  sonatypeProjectHosting := Some(GitHubHosting("testcontainers", "testcontainers-scala", "dimafeng@gmail.com")),
   licenses := Seq("The MIT License (MIT)" -> new URL("https://opensource.org/licenses/MIT")),
   organization in ThisBuild := "com.dimafeng",
 


### PR DESCRIPTION
[Scaladex](https://index.scala-lang.org/)'s data about [`testcontainers-scala`](https://index.scala-lang.org/testcontainers/testcontainers-scala/testcontainers-scala) is extremely incomplete - [only a few old artifacts show up](https://user-images.githubusercontent.com/52038/133003938-aa30b39c-f873-4087-b5b7-2750a7644ace.png)... this is because, back in March 2018 with e983e479, there was a small typo where instead of `GitHubHosting` being specified (which would have been correct), the alternate `GitLabHosting` host was specified in `testcontainers-scala` Sonatype configuration in sbt.

Scaladex is very particular about matching up GitHub repos with their Sonatype metadata (see eg https://github.com/scalacenter/scaladex/issues/657#issuecomment-803899871 ) so this error unfortunately means Scaladex has decided that all releases since then are not associated with the GitHub repo, and does not list them.

Once this typo is corrected, there'll need to be a new release of `testcontainers-scala` to start seeing new releases show up in the right place!

cc @dimafeng