### PR TITLE
Add alias for creating a generic container definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,13 @@ The most flexible but less convenient container type is `GenericContainer`. This
 with custom configuration.
 
 ```scala
-class GenericContainerSpec extends AnyFlatSpec with TestContainerForAll {
-  override val containerDef = GenericContainer.Def("nginx:latest",
+class GenericContainerSpec extends AnyFlatSpec with ForAllTestContainer {
+  override val container: GenericContainer = GenericContainer("nginx:latest",
     exposedPorts = Seq(80),
     waitStrategy = Wait.forHttp("/")
   )
 
-  "GenericContainer" should "start nginx and expose 80 port" in withContainers { case container =>
+  "GenericContainer" should "start nginx and expose 80 port" in {
     assert(Source.fromInputStream(
       new URL(s"http://${container.containerIpAddress}:${container.mappedPort(80)}/").openConnection().getInputStream
     ).mkString.contains("If you see this page, the nginx web server is successfully installed"))
@@ -453,6 +453,15 @@ object NginxContainer {
     ))
   )
 }
+```
+
+However, if you don't want to create a custom container, you can use `GenericContainer` directly while overriding `containerDef`:
+
+```scala
+override val containerDef = GenericContainer.Def("nginx:latest",
+  exposedPorts = Seq(80),
+  waitStrategy = Wait.forHttp("/")
+)
 ```
 
 ### Migration from the classic API

--- a/README.md
+++ b/README.md
@@ -181,13 +181,13 @@ The most flexible but less convenient container type is `GenericContainer`. This
 with custom configuration.
 
 ```scala
-class GenericContainerSpec extends AnyFlatSpec with ForAllTestContainer {
-  override val container: GenericContainer = GenericContainer("nginx:latest",
+class GenericContainerSpec extends AnyFlatSpec with TestContainerForAll {
+  override val containerDef = GenericContainer.Def("nginx:latest",
     exposedPorts = Seq(80),
     waitStrategy = Wait.forHttp("/")
   )
 
-  "GenericContainer" should "start nginx and expose 80 port" in {
+  "GenericContainer" should "start nginx and expose 80 port" in withContainers { case container =>
     assert(Source.fromInputStream(
       new URL(s"http://${container.containerIpAddress}:${container.mappedPort(80)}/").openConnection().getInputStream
     ).mkString.contains("If you see this page, the nginx web server is successfully installed"))

--- a/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
@@ -83,4 +83,36 @@ object GenericContainer {
     override type Container = C
     protected def createContainer(): C = init
   }
+
+  object Def {
+
+    private final case class Default(dockerImage: DockerImage,
+                                     exposedPorts: Seq[Int] = Seq(),
+                                     env: Map[String, String] = Map(),
+                                     command: Seq[String] = Seq(),
+                                     classpathResourceMapping: Seq[(String, String, BindMode)] = Seq(),
+                                     waitStrategy: WaitStrategy = null,
+                                     labels: Map[String, String] = Map.empty,
+                                     tmpFsMapping: Map[String, String] = Map.empty,
+                                     imagePullPolicy: ImagePullPolicy = null) extends Def[GenericContainer](
+      GenericContainer(
+        dockerImage, exposedPorts, env, command, classpathResourceMapping, waitStrategy, 
+        labels, tmpFsMapping, imagePullPolicy)
+    )
+
+    def apply(dockerImage: DockerImage,
+              exposedPorts: Seq[Int] = Seq(),
+              env: Map[String, String] = Map(),
+              command: Seq[String] = Seq(),
+              classpathResourceMapping: Seq[(String, String, BindMode)] = Seq(),
+              waitStrategy: WaitStrategy = null,
+              labels: Map[String, String] = Map.empty,
+              tmpFsMapping: Map[String, String] = Map.empty,
+              imagePullPolicy: ImagePullPolicy = null): GenericContainer.Def[GenericContainer] = 
+      Default(
+        dockerImage, exposedPorts, env, command, classpathResourceMapping, waitStrategy, 
+        labels, tmpFsMapping, imagePullPolicy)
+
+  }
+
 }

--- a/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
@@ -100,7 +100,7 @@ object GenericContainer {
         labels, tmpFsMapping, imagePullPolicy)
     )
 
-    def anonymous(dockerImage: DockerImage,
+    def apply(dockerImage: DockerImage,
               exposedPorts: Seq[Int] = Seq(),
               env: Map[String, String] = Map(),
               command: Seq[String] = Seq(),

--- a/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
@@ -100,7 +100,7 @@ object GenericContainer {
         labels, tmpFsMapping, imagePullPolicy)
     )
 
-    def apply(dockerImage: DockerImage,
+    def anonymous(dockerImage: DockerImage,
               exposedPorts: Seq[Int] = Seq(),
               env: Map[String, String] = Map(),
               command: Seq[String] = Seq(),

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/GenericContainerSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/GenericContainerSpec.scala
@@ -1,0 +1,20 @@
+package com.dimafeng.testcontainers
+
+import org.scalatest.flatspec.AnyFlatSpec
+import scala.io.Source
+import java.net.URL
+import com.dimafeng.testcontainers.scalatest.TestContainerForAll
+import org.testcontainers.containers.wait.strategy.Wait
+
+class GenericContainerSpec extends AnyFlatSpec with TestContainerForAll {
+  override val containerDef = GenericContainer.Def("nginx:latest",
+    exposedPorts = Seq(80),
+    waitStrategy = Wait.forHttp("/")
+  )
+
+  "GenericContainer" should "start nginx and expose 80 port" in withContainers { case container =>
+    assert(Source.fromInputStream(
+      new URL(s"http://${container.containerIpAddress}:${container.mappedPort(80)}/").openConnection().getInputStream
+    ).mkString.contains("If you see this page, the nginx web server is successfully installed"))
+  }
+}

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/GenericContainerSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/GenericContainerSpec.scala
@@ -5,9 +5,10 @@ import scala.io.Source
 import java.net.URL
 import com.dimafeng.testcontainers.scalatest.TestContainerForAll
 import org.testcontainers.containers.wait.strategy.Wait
+import com.dimafeng.testcontainers.GenericContainer.Def
 
 class GenericContainerSpec extends AnyFlatSpec with TestContainerForAll {
-  override val containerDef = GenericContainer.Def("nginx:latest",
+  override val containerDef: Def[GenericContainer] = GenericContainer.Def("nginx:latest",
     exposedPorts = Seq(80),
     waitStrategy = Wait.forHttp("/")
   )


### PR DESCRIPTION
Just adds an alias for creating a `ContainerDef` for a `GenericContainer` that doesn't involve creating a new object/class.

Example:

```scala
import scala.io.Source

import java.net.URL

import org.scalatest.flatspec.AnyFlatSpec

import com.dimafeng.testcontainers.GenericContainer
import com.dimafeng.testcontainers.scalatest.TestContainerForAll

import org.testcontainers.containers.wait.strategy.Wait

class GenericContainerSpec extends AnyFlatSpec with TestContainerForAll {
  
  override val containerDef = GenericContainer.Def.anonymous("nginx:latest",
    exposedPorts = Seq(80),
    waitStrategy = Wait.forHttp("/")
  )

  "GenericContainer" should "start nginx and expose 80 port" in withContainers { container =>
    assert(Source.fromInputStream(
      new URL(s"http://${container.containerIpAddress}::${container.mappedPort(80)}/").openConnection().getInputStream
    ).mkString.contains("If you see this page, the nginx web server is successfully installed"))
  }

}
```