### PR TITLE
Fix:  Image pull policy not applied in GenericContainer

### DIFF
--- a/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
@@ -77,7 +77,8 @@ object GenericContainer {
             labels: Map[String, String] = Map.empty,
             tmpFsMapping: Map[String, String] = Map.empty,
             imagePullPolicy: ImagePullPolicy = null): GenericContainer =
-    new GenericContainer(dockerImage, exposedPorts, env, command, classpathResourceMapping, Option(waitStrategy), labels, tmpFsMapping)
+    new GenericContainer(dockerImage, exposedPorts, env, command, classpathResourceMapping, Option(waitStrategy), labels, tmpFsMapping,
+    Option(imagePullPolicy))
 
   abstract class Def[C <: GenericContainer](init: => C) extends ContainerDef {
     override type Container = C


### PR DESCRIPTION
Closes https://github.com/testcontainers/testcontainers-scala/issues/197
