### PR TITLE
Add startupCheckStrategy

### DIFF
--- a/core/src/main/scala/com/dimafeng/testcontainers/FixedHostPortGenericContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/FixedHostPortGenericContainer.scala
@@ -1,6 +1,7 @@
 package com.dimafeng.testcontainers
 
 import com.dimafeng.testcontainers.GenericContainer.FileSystemBind
+import org.testcontainers.containers.startupcheck.StartupCheckStrategy
 import org.testcontainers.containers.wait.strategy.WaitStrategy
 import org.testcontainers.containers.{BindMode, FixedHostPortGenericContainer => JavaFixedHostPortGenericContainer}
 
@@ -12,7 +13,8 @@ class FixedHostPortGenericContainer(imageName: String,
                                     waitStrategy: Option[WaitStrategy] = None,
                                     exposedHostPort: Int,
                                     exposedContainerPort: Int,
-                                    fileSystemBind: Seq[FileSystemBind] = Seq()
+                                    fileSystemBind: Seq[FileSystemBind] = Seq(),
+                                    startupCheckStrategy: Option[StartupCheckStrategy] = None
                                    ) extends SingleContainer[JavaFixedHostPortGenericContainer[_]] {
 
   override implicit val container: JavaFixedHostPortGenericContainer[_] = new JavaFixedHostPortGenericContainer(imageName)
@@ -33,6 +35,7 @@ class FixedHostPortGenericContainer(imageName: String,
       container.withFileSystemBind(hostFilePath, containerFilePath, bindMode)
   }
   waitStrategy.foreach(container.waitingFor)
+  startupCheckStrategy.foreach(container.withStartupCheckStrategy)
   container.withFixedExposedPort(exposedHostPort, exposedContainerPort)
 }
 

--- a/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
@@ -3,6 +3,7 @@ package com.dimafeng.testcontainers
 import java.util.concurrent.Future
 
 import com.dimafeng.testcontainers.GenericContainer.{FileSystemBind, DockerImage}
+import org.testcontainers.containers.startupcheck.StartupCheckStrategy
 import org.testcontainers.containers.wait.strategy.WaitStrategy
 import org.testcontainers.containers.{BindMode, GenericContainer => JavaGenericContainer}
 import org.testcontainers.images.ImagePullPolicy
@@ -25,7 +26,8 @@ class GenericContainer(
     labels: Map[String, String] = Map.empty,
     tmpFsMapping: Map[String, String] = Map.empty,
     imagePullPolicy: Option[ImagePullPolicy] = None,
-    fileSystemBind: Seq[FileSystemBind] = Seq()
+    fileSystemBind: Seq[FileSystemBind] = Seq(),
+    startupCheckStrategy: Option[StartupCheckStrategy] = None
   ) = this({
     val underlying: JavaGenericContainer[_] = dockerImage match {
       case DockerImage(Left(imageFromDockerfile)) => new JavaGenericContainer(imageFromDockerfile)
@@ -48,6 +50,8 @@ class GenericContainer(
         underlying.withFileSystemBind(hostFilePath, containerFilePath, bindMode)
     }
     waitStrategy.foreach(underlying.waitingFor)
+
+    startupCheckStrategy.foreach(underlying.withStartupCheckStrategy)
 
     if (labels.nonEmpty) {
       underlying.withLabels(labels.asJava)


### PR DESCRIPTION
The PR adds `startupCheckStrategy`  to the DSL for `FixedHostPortGenericContainer` and `GenericContainer`.