### PR TITLE
Localstack (+V2) dependencies

### DIFF
--- a/modules/localstackV2/src/main/scala/com/dimafeng/testcontainers/LocalStackV2Container.scala
+++ b/modules/localstackV2/src/main/scala/com/dimafeng/testcontainers/LocalStackV2Container.scala
@@ -30,7 +30,7 @@ case class LocalStackV2Container(
 object LocalStackV2Container {
 
 
-  val defaultTag = "0.9.4"
+  val defaultTag = "0.12.12"
 
   type Service = JavaLocalStackContainer.EnabledService
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -206,7 +206,8 @@ object Dependencies {
     COMPILE(
       "org.testcontainers" % "localstack" % testcontainersVersion
     ) ++ PROVIDED(
-      "software.amazon.awssdk" % "s3" % awsV2Version
+      "software.amazon.awssdk" % "s3" % awsV2Version,
+      "software.amazon.awssdk" % "sqs" % awsV2Version
     )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   private val mockitoVersion = "3.7.7"
   private val restAssuredVersion = "4.0.0"
   private val awsV1Version = "1.11.479"
-  private val awsV2Version = "2.15.7"
+  private val awsV2Version = "2.17.158"
   private val sttpVersion = "3.3.14"
   private val firestoreConnectorVersion = "3.0.11"
   private val bigtableVersion = "2.5.3"
@@ -198,7 +198,8 @@ object Dependencies {
     COMPILE(
       "org.testcontainers" % "localstack" % testcontainersVersion
     ) ++ PROVIDED(
-      "com.amazonaws" % "aws-java-sdk-s3" % awsV1Version
+      "com.amazonaws" % "aws-java-sdk-s3" % awsV1Version,
+      "com.amazonaws" % "aws-java-sdk-sqs" % awsV1Version
     )
   )
 


### PR DESCRIPTION
Hey there! 👋 

For reasons similar @jbwheatley's previous localstack PRs/issues:

https://github.com/testcontainers/testcontainers-scala/issues/135
https://github.com/testcontainers/testcontainers-scala/pull/136

... I need to introduce the sqs dependency for the localstack to avoid the dreaded 

```
A needed class was not found. This could be due to an error in your runpath. Missing class: com/amazonaws/auth/AWSCredentials
java.lang.NoClassDefFoundError: com/amazonaws/auth/AWSCredentials
```

 I hope it's ok that as part of this I've also bumped the aws library version + the default tag for the V2 stack to bring it in line with V1 as per https://github.com/testcontainers/testcontainers-scala/pull/183
 
