### PR TITLE
Add Java 17 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java:
+          - 8
           - 11
+          - 17
 #          - graalvm-ce-java11@20.3.0
     runs-on: ${{ matrix.os }}
     steps:

--- a/modules/gcloud/src/test/scala/com/dimafeng/testcontainers/FirestoreEmulatorContainerSpec.scala
+++ b/modules/gcloud/src/test/scala/com/dimafeng/testcontainers/FirestoreEmulatorContainerSpec.scala
@@ -3,7 +3,7 @@ package com.dimafeng.testcontainers
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import java.util.{Map => JMap}
+import scala.collection.JavaConverters._
 
 class FirestoreEmulatorContainerSpec extends AnyWordSpecLike with Matchers with ForAllTestContainer {
 
@@ -16,8 +16,8 @@ class FirestoreEmulatorContainerSpec extends AnyWordSpecLike with Matchers with 
       try {
         val users = firestore.collection("users")
         val docRef = users.document("alovelace")
-        val data = JMap.of("first", "Ada", "last", "Lovelace")
-        val eventualInit = docRef.set(data)
+        val data = Map[String, Any]("first" -> "Ada", "last" -> "Lovelace")
+        val eventualInit = docRef.set(data.asJava)
         eventualInit.get()
 
         val eventualSnapshot = users.get()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,6 +29,7 @@ object Dependencies {
   private val kafkaDriverVersion = "2.2.0"
   private val mockitoVersion = "3.7.7"
   private val restAssuredVersion = "4.0.0"
+  private val groovyVersion = "2.5.16"
   private val awsV1Version = "1.11.479"
   private val awsV2Version = "2.17.158"
   private val sttpVersion = "3.3.14"
@@ -137,7 +138,9 @@ object Dependencies {
     COMPILE(
       "org.testcontainers" % "vault" % testcontainersVersion
     ) ++ TEST(
-      "io.rest-assured" % "scala-support" % restAssuredVersion
+      ("io.rest-assured" % "scala-support" % restAssuredVersion)
+        .exclude("org.codehaus.groovy", "groovy"),
+      "org.codehaus.groovy"% "groovy" % groovyVersion
     )
   )
 


### PR DESCRIPTION
Ensuring (via CI/CD) that tests run in Java env 8, 11 and 17.

**Note 1:** Fixed error with Java 8
```
[error] .../testcontainers-scala/modules/gcloud/src/test/scala/com/dimafeng/testcontainers/FirestoreEmulatorContainerSpec.scala:19:25: value of is not a member of object java.util.Map
[error]         val data = JMap.of("first", "Ada", "last", "Lovelace")
```

**Note 2: ** Fixed error with Java 17
```
[info] com.dimafeng.testcontainers.integration.VaultSpec *** ABORTED ***
[info]   java.lang.NoClassDefFoundError: Could not initialize class org.codehaus.groovy.reflection.ReflectionCache
[info]   at org.codehaus.groovy.runtime.dgmimpl.NumberNumberMetaMethod.<clinit>(NumberNumberMetaMethod.java:33)
[info]   ...
[info]   Cause: java.lang.ExceptionInInitializerError: Exception java.lang.NoClassDefFoundError: Could not initialize class org.codehaus.groovy.vmplugin.v7.Java7 [in thread "pool-1-thread-1-ScalaTest-running-VaultSpec"]
```
