### PR TITLE
Fix KafkaContainer not running as expected on ARM64

### DIFF
--- a/modules/kafka/src/main/scala/com/dimafeng/testcontainers/KafkaContainer.scala
+++ b/modules/kafka/src/main/scala/com/dimafeng/testcontainers/KafkaContainer.scala
@@ -3,7 +3,10 @@ package com.dimafeng.testcontainers
 import org.testcontainers.containers.{KafkaContainer => JavaKafkaContainer}
 import org.testcontainers.utility.DockerImageName
 
-case class KafkaContainer(dockerImageName: DockerImageName = DockerImageName.parse(KafkaContainer.defaultDockerImageName)
+import scala.util.Try
+import scala.sys.process._
+
+case class KafkaContainer(dockerImageName: DockerImageName = KafkaContainer.defaultDockerImage
                     ) extends SingleContainer[JavaKafkaContainer] {
 
   override val container: JavaKafkaContainer = new JavaKafkaContainer(dockerImageName)
@@ -13,20 +16,40 @@ case class KafkaContainer(dockerImageName: DockerImageName = DockerImageName.par
 
 object KafkaContainer {
 
-  val defaultImage = Option(System.getProperty("os.arch")) match {
-    /* 
+  private lazy val runningOnArm64: Boolean =
+    // This shouldn't fail (`null` if it doesn't exist), however just in case...
+    // `os.arch` is `x86_64` if we are on an x86 machine _or_ the JVM is running under Rosetta 2 (emulation).
+    // `aarch64` if we are on ARM64 _and_ not running under Rosetta 2 (emulation).
+    Try(System.getProperty("os.arch")).toOption.exists {
+      // We know we definitely are on an ARM64 processor
+      case "aarch64" => true
+      // We may be on ARM64 if the JVM is being emulated, find if it is running under Rosetta 2
+      case _ => runningUnderRosetta2
+    }
+
+  // `sysctl -n sysctl.proc_translated` is defined on Apple ARM64 devices.
+  // It returns `0` when running natively and `1` when running the current process under Rosetta 2.
+  private lazy val runningUnderRosetta2: Boolean =
+    // ProcessLogger redirects any error output away from console to a noop receiver (effectively `/dev/null`)
+    Try("sysctl -n sysctl.proc_translated".!!(ProcessLogger(_ => ()))).toOption.exists(_.trim == "1")
+
+  private val confluentKafkaImage = "confluentinc/cp-kafka"
+
+  val defaultImage =
+    /*
     * The official Confluent docker image does not work with ARM64.
     * See https://github.com/confluentinc/common-docker/issues/117,
     * https://github.com/confluentinc/kafka-images/issues/80
     */
-    case Some("aarch64") => "niciqy/cp-kafka-arm64"
-    case _ => "confluentinc/cp-kafka"
-  }
+    if (runningOnArm64) "niciqy/cp-kafka-arm64" else confluentKafkaImage
+
   val defaultTag = "7.0.1"
   val defaultDockerImageName = s"$defaultImage:$defaultTag"
 
-  case class Def(dockerImageName: DockerImageName = DockerImageName.parse(KafkaContainer.defaultDockerImageName)
-                ) extends ContainerDef {
+  private val defaultDockerImage =
+    DockerImageName.parse(KafkaContainer.defaultDockerImageName).asCompatibleSubstituteFor(confluentKafkaImage)
+
+  case class Def(dockerImageName: DockerImageName = defaultDockerImage) extends ContainerDef {
 
     override type Container = KafkaContainer
 

--- a/modules/kafka/src/test/scala/com/dimafeng/testcontainers/integration/SchemaRegistrySpec.scala
+++ b/modules/kafka/src/test/scala/com/dimafeng/testcontainers/integration/SchemaRegistrySpec.scala
@@ -27,7 +27,7 @@ class SchemaRegistrySpec extends AnyFlatSpec with ForAllTestContainer with Match
   //a way to communicate containers
   val network: Network = Network.newNetwork()
 
-  val kafkaContainer: KafkaContainer = KafkaContainer.Def(DockerImageName.parse(s"confluentinc/cp-kafka:$kafkaVersion")).createContainer()
+  val kafkaContainer: KafkaContainer = KafkaContainer.Def().createContainer()
   val schemaRegistryContainer: GenericContainer = SchemaRegistryContainer.Def(network, hostName, kafkaVersion).createContainer()
 
   kafkaContainer.container


### PR DESCRIPTION
There are two issues with the current implementation.

The first is that the ARM64 image (`niciqy/cp-kafka-arm64`) is not
marked as a compatible substitute for the confluent image
(`confluentinc/cp-kafka`). This means a runtime failure executing tests.

The second is that `System.getProperty("os.arch")` does not return
`aarch64` on an x86 (AMD64) JVM being emulated by Rosetta 2 on MacOS
(for example because other parts of compilation/testing require an x86
JDK). End-users _probably_ want to use an ARM64 Kafka image in this
situation as they (probably) won't need an emulated Kafka container
running. A call to `sysctl` can determine if the current process (the
JVM) is running under Rosetta 2 and so if the underlying CPU is actually
ARM64.

These changes are being used internally and have worked (so far!) for
users on both x86 and ARM64 MacOS machines.