### PR TITLE
Make OracleContainer extend JdbcDatabaseContainer

### DIFF
--- a/modules/oracle/src/main/scala/com/dimafeng/testcontainers/OracleContainer.scala
+++ b/modules/oracle/src/main/scala/com/dimafeng/testcontainers/OracleContainer.scala
@@ -17,7 +17,7 @@ case class OracleContainer(
   oraPassword: String = OracleContainer.defaultPassword,
   containerSharedMemory: Long = OracleContainer.defaultSharedMemory,
   commonJdbcParams: JdbcDatabaseContainer.CommonParams = OracleContainer.defaultCommonJdbcParams
-) extends SingleContainer[JavaOracleContainer] {
+) extends SingleContainer[JavaOracleContainer] with JdbcDatabaseContainer {
 
   override val container: JavaOracleContainer = {
     val c = new JavaOracleContainer(dockerImageName)
@@ -27,14 +27,6 @@ case class OracleContainer(
     commonJdbcParams.applyTo(c)
     c
   }
-
-  def driverClassName: String = container.getDriverClassName
-
-  def jdbcUrl: String = container.getJdbcUrl
-
-  def username: String = container.getUsername
-
-  def password: String = container.getPassword
 
   def testQueryString: String = container.getTestQueryString
 }


### PR DESCRIPTION
OracleContainer is the only RDBMS container that doesn't implement JdbcDatabaseContainer. It makes it hard to work with these containers in a more abstract way.