### PR TITLE
Fix MockServer container tag

### DIFF
--- a/modules/mockserver/src/main/scala/com/dimafeng/testcontainers/MockServerContainer.scala
+++ b/modules/mockserver/src/main/scala/com/dimafeng/testcontainers/MockServerContainer.scala
@@ -1,12 +1,16 @@
 package com.dimafeng.testcontainers
 
 import org.testcontainers.containers.{MockServerContainer => JavaMockServerContainer}
+import org.testcontainers.utility.DockerImageName
 
 case class MockServerContainer(
   version: String = MockServerContainer.defaultVersion
 ) extends SingleContainer[JavaMockServerContainer] {
 
-  override val container: JavaMockServerContainer = new JavaMockServerContainer(version)
+  override val container: JavaMockServerContainer = 
+    new JavaMockServerContainer(
+      MockServerContainer.defaultImageName.withTag(s"mockserver-$version")
+    )
 
   def endpoint: String = container.getEndpoint
 
@@ -15,10 +19,12 @@ case class MockServerContainer(
 
 object MockServerContainer {
 
-  val defaultVersion = JavaMockServerContainer.VERSION
+  private[testcontainers] final val defaultImageName = DockerImageName.parse("mockserver/mockserver")
+
+  private[testcontainers] final val defaultVersion = "5.13.2"
 
   case class Def(
-    version: String = MockServerContainer.defaultVersion
+    version: String = defaultVersion
   ) extends ContainerDef {
 
     override type Container = MockServerContainer


### PR DESCRIPTION
Solves https://github.com/testcontainers/testcontainers-scala/issues/213

Current MockServerContainer uses deprecated constructors from testcontainers-java. This PR introduces constructing image name using DockerImageName utility without changing the API of MockServerContainer.
Unfortunately there's no way to use the defaults from testcontainers-java because they're declared as private, so in this PR I'm introducing the latest image from `mockserver/mockserver` repo (as opposed to the deprecated `jamesdbloom/mockserver` used by testcontainers-java).