### PR TITLE
ContainerDef constructors for gcloud containers

### DIFF
--- a/modules/gcloud/src/main/scala/com/dimafeng/testcontainers/BigtableEmulatorContainer.scala
+++ b/modules/gcloud/src/main/scala/com/dimafeng/testcontainers/BigtableEmulatorContainer.scala
@@ -57,4 +57,16 @@ object BigtableEmulatorContainer {
 
   val defaultImageName: DockerImageName =
     DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk")
+
+  case class Def(
+    bigtableEmulatorImageName: Option[DockerImageName] = None,
+    projectId: String = BigtableEmulatorContainer.defaultProjectId,
+    instanceId: String = BigtableEmulatorContainer.defaultInstanceId
+  ) extends ContainerDef {
+
+    override type Container = BigtableEmulatorContainer
+
+    override def createContainer(): BigtableEmulatorContainer =
+      new BigtableEmulatorContainer(bigtableEmulatorImageName, projectId, instanceId)
+  }
 }

--- a/modules/gcloud/src/main/scala/com/dimafeng/testcontainers/FirestoreEmulatorContainer.scala
+++ b/modules/gcloud/src/main/scala/com/dimafeng/testcontainers/FirestoreEmulatorContainer.scala
@@ -34,4 +34,12 @@ object FirestoreEmulatorContainer {
   ): FirestoreEmulatorContainer =
     new FirestoreEmulatorContainer(Option(firestoreEmulatorImageName))
 
+  case class Def(firestoreEmulatorImageName: Option[DockerImageName] = None) extends ContainerDef {
+
+    override type Container = FirestoreEmulatorContainer
+
+    override def createContainer(): FirestoreEmulatorContainer =
+      new FirestoreEmulatorContainer(firestoreEmulatorImageName)
+  }
+
 }

--- a/modules/gcloud/src/main/scala/com/dimafeng/testcontainers/PubSubEmulatorContainer.scala
+++ b/modules/gcloud/src/main/scala/com/dimafeng/testcontainers/PubSubEmulatorContainer.scala
@@ -75,6 +75,14 @@ object PubSubEmulatorContainer {
            ): PubSubEmulatorContainer =
     new PubSubEmulatorContainer(Option(pubsubEmulatorImageName))
 
+  case class Def(pubSubEmulatorImageName: Option[DockerImageName] = None) extends ContainerDef {
+
+    override type Container = PubSubEmulatorContainer
+
+    override def createContainer(): PubSubEmulatorContainer =
+      new PubSubEmulatorContainer(pubSubEmulatorImageName)
+  }
+
 }
 
 


### PR DESCRIPTION
These are needed if using testcontainers-scala with munit. 