### PR TITLE
Update Kafka version, remove ARM-specific image name

### DIFF
--- a/modules/kafka/src/main/scala/com/dimafeng/testcontainers/KafkaContainer.scala
+++ b/modules/kafka/src/main/scala/com/dimafeng/testcontainers/KafkaContainer.scala
@@ -13,16 +13,8 @@ case class KafkaContainer(dockerImageName: DockerImageName = DockerImageName.par
 
 object KafkaContainer {
 
-  val defaultImage = Option(System.getProperty("os.arch")) match {
-    /* 
-    * The official Confluent docker image does not work with ARM64.
-    * See https://github.com/confluentinc/common-docker/issues/117,
-    * https://github.com/confluentinc/kafka-images/issues/80
-    */
-    case Some("aarch64") => "niciqy/cp-kafka-arm64"
-    case _ => "confluentinc/cp-kafka"
-  }
-  val defaultTag = "7.0.1"
+  val defaultImage = "confluentinc/cp-kafka"
+  val defaultTag = "7.2.0"
   val defaultDockerImageName = s"$defaultImage:$defaultTag"
 
   case class Def(dockerImageName: DockerImageName = DockerImageName.parse(KafkaContainer.defaultDockerImageName)


### PR DESCRIPTION
Confluent now provides official arm64-based images. Supersedes #223 