### PR TITLE
rev testcontainers to 1.17.5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     scope.map(s => modules.map(_ % s)).getOrElse(modules)
   }
 
-  private val testcontainersVersion = "1.17.3"
+  private val testcontainersVersion = "1.17.5"
   private val seleniumVersion = "2.53.1"
   private val slf4jVersion = "1.7.32"
   private val scalaTestVersion = "3.2.9"


### PR DESCRIPTION
I get three test failures locally:

```
[error] (moduleOracle / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (scalatestSelenium / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (moduleNeo4j / Test / test) sbt.TestsFailedException: Tests unsuccessful
```

I was hoping CI would run on PRs here - locally they may be because of running on Apple Silicon 