### PR TITLE
Align localstack v1 with other containers allowing to override docker image entirely

### DIFF
--- a/modules/localstack/src/main/scala/com/dimafeng/testcontainers/LocalStackContainer.scala
+++ b/modules/localstack/src/main/scala/com/dimafeng/testcontainers/LocalStackContainer.scala
@@ -3,14 +3,15 @@ package com.dimafeng.testcontainers
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.client.builder.AwsClientBuilder
 import org.testcontainers.containers.localstack.{LocalStackContainer => JavaLocalStackContainer}
+import org.testcontainers.utility.DockerImageName
 
 case class LocalStackContainer(
-  tag: String = LocalStackContainer.defaultTag,
+  dockerImageName: DockerImageName = DockerImageName.parse(LocalStackContainer.defaultDockerImageName),
   services: Seq[LocalStackContainer.Service] = Seq.empty
 ) extends SingleContainer[JavaLocalStackContainer] {
 
   override val container: JavaLocalStackContainer = {
-    val c = new JavaLocalStackContainer(tag)
+    val c = new JavaLocalStackContainer(dockerImageName)
     c.withServices(services: _*)
     c
   }
@@ -23,12 +24,14 @@ case class LocalStackContainer(
 
 object LocalStackContainer {
 
+  val defaultImage = "localstack/localstack"
   val defaultTag = "0.12.12"
+  val defaultDockerImageName = s"$defaultImage:$defaultTag"
 
   type Service = JavaLocalStackContainer.Service
 
   case class Def(
-    tag: String = LocalStackContainer.defaultTag,
+    dockerImageName: DockerImageName = DockerImageName.parse(LocalStackContainer.defaultDockerImageName),
     services: Seq[LocalStackContainer.Service] = Seq.empty
   ) extends ContainerDef {
 
@@ -36,7 +39,7 @@ object LocalStackContainer {
 
     override def createContainer(): LocalStackContainer = {
       new LocalStackContainer(
-        tag,
+        dockerImageName,
         services
       )
     }


### PR DESCRIPTION
In our company, we might want to change the image name completely. The current module version forces us to use `localstack/localstack`. Additionally, the old constructor that receives the tag parameter is deprecated.