### PR TITLE
update testcontainers-java to 1.18.1

### DIFF
--- a/modules/localstack/src/main/scala/com/dimafeng/testcontainers/LocalStackContainer.scala
+++ b/modules/localstack/src/main/scala/com/dimafeng/testcontainers/LocalStackContainer.scala
@@ -1,7 +1,5 @@
 package com.dimafeng.testcontainers
 
-import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.client.builder.AwsClientBuilder
 import org.testcontainers.containers.localstack.{LocalStackContainer => JavaLocalStackContainer}
 import org.testcontainers.utility.DockerImageName
 
@@ -15,11 +13,6 @@ case class LocalStackContainer(
     c.withServices(services: _*)
     c
   }
-
-  def endpointConfiguration(service: LocalStackContainer.Service): AwsClientBuilder.EndpointConfiguration =
-    container.getEndpointConfiguration(service)
-
-  def defaultCredentialsProvider: AWSCredentialsProvider = container.getDefaultCredentialsProvider
 }
 
 object LocalStackContainer {

--- a/modules/vault/src/test/scala/com/dimafeng/testcontainers/integration/VaultSpec.scala
+++ b/modules/vault/src/test/scala/com/dimafeng/testcontainers/integration/VaultSpec.scala
@@ -5,11 +5,12 @@ import io.restassured.RestAssured.given
 import io.restassured.module.scala.RestAssuredSupport.AddThenToResponse
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
+import org.testcontainers.utility.DockerImageName
 
 class VaultSpec extends AnyFlatSpec with ForAllTestContainer with Matchers {
 
   private val port = 8200
-  override val container: VaultContainer = VaultContainer(vaultPort = Some(port))
+  override val container: VaultContainer = VaultContainer(DockerImageName.parse("vault:1.1.3"), vaultPort = Some(port))
 
   "Vault container" should "be started" in {
     given().

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     scope.map(s => modules.map(_ % s)).getOrElse(modules)
   }
 
-  private val testcontainersVersion = "1.17.5"
+  private val testcontainersVersion = "1.18.1"
   private val seleniumVersion = "2.53.1"
   private val slf4jVersion = "1.7.32"
   private val scalaTestVersion = "3.2.9"


### PR DESCRIPTION
Hi,

I updated the testcontainers-java dependecy to the newest version.
My main reason was that it removes the AWS SDK V1 dependency for the Localstack Module.

The change in the Vault module was needed because of this change:
https://github.com/testcontainers/testcontainers-java/pull/6796

In the Localstack module the (deprecated) functions were removed from the java library:
https://github.com/testcontainers/testcontainers-java/pull/5827

also solves https://github.com/testcontainers/testcontainers-scala/issues/234