### PR TITLE
update sbt-pgp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build/
 out
 target/
 project/project/
+.bloop/
+.metals/
+project/**/metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,6 @@ val commonSettings = Seq(
   /**
    * Publishing
    */
-  useGpg := true,
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     if (isSnapshot.value) {

--- a/project/Plugins.sbt
+++ b/project/Plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")


### PR DESCRIPTION
`useGpg := true,` is default in `com.github.sbt" % "sbt-pgp` [deprecated](https://github.com/sbt/sbt-pgp/blob/94c5af71b2d8ccc903f7b3435430aa64f28b6b2d/sbt-pgp/src/main/scala/com/jsuereth/sbtpgp/SbtPgp.scala#LL21C8-L21C8) since '2.0.0'