### PR TITLE
update deps

### DIFF
--- a/core/src/test/scala/com/dimafeng/testcontainers/BaseSpec.scala
+++ b/core/src/test/scala/com/dimafeng/testcontainers/BaseSpec.scala
@@ -12,5 +12,5 @@ abstract class BaseSpec[T: ClassTag]
 
   behavior of implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]].getSimpleName
 
-  override def beforeEach(): Unit = MockitoAnnotations.initMocks(this)
+  override def beforeEach(): Unit = MockitoAnnotations.openMocks(this)
 }

--- a/modules/cassandra/src/test/scala/com/dimafeng/testcontainers/integration/CassandraSpec.scala
+++ b/modules/cassandra/src/test/scala/com/dimafeng/testcontainers/integration/CassandraSpec.scala
@@ -15,7 +15,7 @@ class CassandraSpec extends AnyFlatSpec with ForAllTestContainer with Matchers {
 
     val session = CqlSession.builder
       .addContactEndPoint(new DefaultEndPoint(InetSocketAddress
-      .createUnresolved(container.cassandraContainer.getContainerIpAddress,
+      .createUnresolved(container.cassandraContainer.getHost,
                         container.cassandraContainer.getFirstMappedPort.intValue())))
       .withLocalDatacenter("datacenter1").build()
     val rs = session.execute("select release_version from system.local")

--- a/modules/kafka/src/test/scala/com/dimafeng/testcontainers/integration/SchemaRegistrySpec.scala
+++ b/modules/kafka/src/test/scala/com/dimafeng/testcontainers/integration/SchemaRegistrySpec.scala
@@ -55,7 +55,7 @@ class SchemaRegistrySpec extends AnyFlatSpec with ForAllTestContainer with Match
     adminProperties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaAddress)
 
     val adminClient = AdminClient.create(adminProperties)
-    val createTopicResult = adminClient.createTopics(List(new NewTopic(topicName, 1, 1)).asJava)
+    val createTopicResult = adminClient.createTopics(List(new NewTopic(topicName, 1, 1.shortValue())).asJava)
     createTopicResult.values().get(topicName).get()
 
     val properties = new Properties()

--- a/modules/mariadb/src/main/scala/com/dimafeng/testcontainers/MariaDBContainer.scala
+++ b/modules/mariadb/src/main/scala/com/dimafeng/testcontainers/MariaDBContainer.scala
@@ -34,7 +34,7 @@ case class MariaDBContainer(
 
 object MariaDBContainer {
 
-  val defaultDockerImageName = s"${JavaMariaDBContainer.IMAGE}:${JavaMariaDBContainer.DEFAULT_TAG}"
+  val defaultDockerImageName = s"${JavaMariaDBContainer.NAME}"
   val defaultDatabaseName = "test"
   val defaultUsername = "test"
   val defaultPassword = "test"

--- a/modules/mongodb/src/main/scala/com/dimafeng/testcontainers/MongoDBContainer.scala
+++ b/modules/mongodb/src/main/scala/com/dimafeng/testcontainers/MongoDBContainer.scala
@@ -6,25 +6,24 @@ import org.testcontainers.utility.DockerImageName
 case class MongoDBContainer(
   tag: Option[DockerImageName] = None
 ) extends SingleContainer[JavaMongoDBContainer] {
+  private val defaultImageName = DockerImageName.parse("mongo")
+  private val defaultMongoTag = "4.0.10"
 
   override val container: JavaMongoDBContainer = tag match {
     case Some(tag) => new JavaMongoDBContainer(tag)
-    case None      => new JavaMongoDBContainer()
+    case None      => new JavaMongoDBContainer(defaultImageName.withTag(defaultMongoTag))
   }
 
   def replicaSetUrl: String = container.getReplicaSetUrl
 }
 
 object MongoDBContainer {
-
-  def apply(tag: DockerImageName): MongoDBContainer = new MongoDBContainer(Option(tag))
-
   case class Def(
-    tag: DockerImageName = null
+    tag: Option[DockerImageName]
   ) extends ContainerDef {
 
     override type Container = MongoDBContainer
 
-    override def createContainer(): MongoDBContainer = new MongoDBContainer(Option(tag))
+    override def createContainer(): MongoDBContainer = new MongoDBContainer(tag)
   }
 }

--- a/modules/mongodb/src/test/scala/com/dimafeng/testcontainers/integration/MongoSpec.scala
+++ b/modules/mongodb/src/test/scala/com/dimafeng/testcontainers/integration/MongoSpec.scala
@@ -3,11 +3,12 @@ package com.dimafeng.testcontainers.integration
 import com.dimafeng.testcontainers.{Container, ForAllTestContainer, MongoDBContainer, MultipleContainers}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.testcontainers.utility.DockerImageName
 
 class MongoSpec extends AnyFlatSpec with ForAllTestContainer with Matchers {
 
   private val mongoDefault = MongoDBContainer()
-  private val mongo = MongoDBContainer("mongo:4.0.10")
+  private val mongo = MongoDBContainer(Option(DockerImageName.parse("mongo").withTag("4.0.10")))
 
   override val container: Container = MultipleContainers(
     mongoDefault, mongo

--- a/modules/oracle/src/test/scala/com/dimafeng/testcontainers/OracleSpec.scala
+++ b/modules/oracle/src/test/scala/com/dimafeng/testcontainers/OracleSpec.scala
@@ -1,12 +1,12 @@
 package com.dimafeng.testcontainers
 
 import java.sql.DriverManager
-
 import org.scalatest.flatspec.AnyFlatSpec
+import org.testcontainers.utility.DockerImageName
 
 class OracleSpec extends AnyFlatSpec with ForAllTestContainer {
 
-  override val container: OracleContainer = OracleContainer("gvenzl/oracle-xe:18.4.0-slim")
+  override val container: OracleContainer = OracleContainer(DockerImageName.parse("gvenzl/oracle-xe:18.4.0-slim"))
 
   "Oracle container" should "be started" in {
     System.setProperty("oracle.jdbc.timezoneAsRegion", "false")

--- a/modules/vault/src/test/scala/com/dimafeng/testcontainers/integration/VaultSpec.scala
+++ b/modules/vault/src/test/scala/com/dimafeng/testcontainers/integration/VaultSpec.scala
@@ -2,10 +2,10 @@ package com.dimafeng.testcontainers.integration
 
 import com.dimafeng.testcontainers.{ForAllTestContainer, VaultContainer}
 import io.restassured.RestAssured.given
-import io.restassured.module.scala.RestAssuredSupport.AddThenToResponse
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 import org.testcontainers.utility.DockerImageName
+
 
 class VaultSpec extends AnyFlatSpec with ForAllTestContainer with Matchers {
 
@@ -17,7 +17,7 @@ class VaultSpec extends AnyFlatSpec with ForAllTestContainer with Matchers {
       baseUri(s"http://${container.containerIpAddress}:${container.mappedPort(port)}").
       when().
       get("/v1/sys/health").
-      Then().
+      `then`().
       statusCode(200)
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,29 +13,29 @@ object Dependencies {
   }
 
   private val testcontainersVersion = "1.18.1"
-  private val seleniumVersion = "2.53.1"
-  private val slf4jVersion = "1.7.32"
-  private val scalaTestVersion = "3.2.9"
-  private val scalaTestMockitoVersion = "3.2.9.0"
+  private val seleniumVersion = "4.8.1"
+  private val slf4jVersion = "2.0.5"
+  private val scalaTestVersion = "3.2.15"
+  private val scalaTestMockitoVersion = "3.2.10.0"
   private val scalaTestSeleniumVersion_scala2 = "3.2.2.0"
   private val scalaTestSeleniumVersion_scala3 = "3.2.9.0"
   private val junitVersion = "4.13.2"
   private val munitVersion = "1.0.0-M7"
-  private val mysqlConnectorVersion = "5.1.42"
-  private val neo4jConnectorVersion = "4.0.0"
-  private val oracleDriverVersion = "21.3.0.0"
-  private val cassandraDriverVersion = "4.0.1"
-  private val postgresqlDriverVersion = "42.2.24"
-  private val kafkaDriverVersion = "2.2.0"
+  private val mysqlConnectorVersion = "8.0.33"
+  private val neo4jConnectorVersion = "5.6.0"
+  private val oracleDriverVersion = "21.9.0.0"
+  private val cassandraDriverVersion = "4.15.0"
+  private val postgresqlDriverVersion = "42.5.4"
+  private val kafkaDriverVersion = "3.4.0"
   private val mockitoVersion = "3.7.7"
-  private val restAssuredVersion = "4.0.0"
-  private val groovyVersion = "2.5.16"
-  private val awsV1Version = "1.11.479"
-  private val awsV2Version = "2.17.158"
-  private val sttpVersion = "3.3.14"
-  private val firestoreConnectorVersion = "3.0.11"
-  private val bigtableVersion = "2.5.3"
-  private val pubsubVersion = "1.116.4"
+  private val restAssuredVersion = "5.3.1"
+  private val groovyVersion = "3.0.16"
+  private val awsV1Version = "1.12.472"
+  private val awsV2Version = "2.20.68"
+  private val sttpVersion = "3.8.13"
+  private val firestoreConnectorVersion = "3.9.1"
+  private val bigtableVersion = "2.20.0"
+  private val pubsubVersion = "1.123.6"
 
   val allOld = Def.setting(
     PROVIDED(
@@ -154,7 +154,7 @@ object Dependencies {
     COMPILE(
       "org.testcontainers" % "clickhouse" % testcontainersVersion
     ) ++ TEST(
-      "ru.yandex.clickhouse" % "clickhouse-jdbc" % "0.2.4",
+      "ru.yandex.clickhouse" % "clickhouse-jdbc" % "0.3.2",
     )
   )
 
@@ -194,7 +194,7 @@ object Dependencies {
     COMPILE(
       "org.testcontainers" % "influxdb" % testcontainersVersion
     ) ++ PROVIDED(
-      "org.influxdb" % "influxdb-java" % "2.17"
+      "org.influxdb" % "influxdb-java" % "2.23"
     )
   )
 

--- a/test-framework/scalatest-selenium/src/test/scala/com/dimafeng/testcontainers/integration/SeleniumSpec.scala
+++ b/test-framework/scalatest-selenium/src/test/scala/com/dimafeng/testcontainers/integration/SeleniumSpec.scala
@@ -1,12 +1,13 @@
 package com.dimafeng.testcontainers.integration
 
 import com.dimafeng.testcontainers.SeleniumTestContainerSuite
+import org.openqa.selenium.Platform
 import org.openqa.selenium.remote.DesiredCapabilities
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.selenium.WebBrowser
 
 class SeleniumSpec extends AnyFlatSpec with SeleniumTestContainerSuite with WebBrowser {
-  override def desiredCapabilities = DesiredCapabilities.chrome()
+  override def desiredCapabilities: DesiredCapabilities = new DesiredCapabilities("chrome", "1.0", Platform.LINUX)
 
   "Browser" should "show google" in {
     go to "http://google.com"

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/GenericContainerSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/GenericContainerSpec.scala
@@ -1,8 +1,9 @@
 package com.dimafeng.testcontainers
 
 import org.scalatest.flatspec.AnyFlatSpec
+
 import scala.io.Source
-import java.net.URL
+import java.net.{URI, URL}
 import com.dimafeng.testcontainers.scalatest.TestContainerForAll
 import org.testcontainers.containers.wait.strategy.Wait
 import com.dimafeng.testcontainers.GenericContainer.Def
@@ -15,7 +16,7 @@ class GenericContainerSpec extends AnyFlatSpec with TestContainerForAll {
 
   "GenericContainer" should "start nginx and expose 80 port" in withContainers { case container =>
     assert(Source.fromInputStream(
-      new URL(s"http://${container.containerIpAddress}:${container.mappedPort(80)}/").openConnection().getInputStream
+      new URI(s"http://${container.containerIpAddress}:${container.mappedPort(80)}/").toURL.openConnection().getInputStream
     ).mkString.contains("If you see this page, the nginx web server is successfully installed"))
   }
 }

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/FixedHostPortContainerSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/FixedHostPortContainerSpec.scala
@@ -1,7 +1,6 @@
 package com.dimafeng.testcontainers.integration
 
-import java.net.URL
-
+import java.net.{URI, URL}
 import com.dimafeng.testcontainers.{FixedHostPortGenericContainer, ForAllTestContainer}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
@@ -18,7 +17,7 @@ class FixedHostPortContainerSpec extends AnyFlatSpec with ForAllTestContainer {
   "FixedHostPortGenericContainer" should "start nginx and expose 8090 port on host" in {
     assert(container.mappedPort(80) == 8090)
     assert(Source.fromInputStream(
-      new URL(s"http://${container.containerIpAddress}:${container.mappedPort(80)}/").openConnection().getInputStream
+      new URI(s"http://${container.containerIpAddress}:${container.mappedPort(80)}/").toURL.openConnection().getInputStream
     ).mkString.contains("If you see this page, the nginx web server is successfully installed"))
   }
 }

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/GenericContainerDefSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/GenericContainerDefSpec.scala
@@ -1,7 +1,6 @@
 package com.dimafeng.testcontainers.integration
 
-import java.net.URL
-
+import java.net.{URI, URL}
 import com.dimafeng.testcontainers.{GenericContainer, SingleContainer}
 import com.dimafeng.testcontainers.lifecycle.and
 import com.dimafeng.testcontainers.scalatest.TestContainersForAll
@@ -35,8 +34,8 @@ object GenericContainerDefSpec {
 
   private val port = 80
 
-  private def createUrl(container: SingleContainer[_]) = {
-    new URL(s"http://${container.containerIpAddress}:${container.mappedPort(port)}/")
+  private def createUrl(container: SingleContainer[_]): URL = {
+    new URI(s"http://${container.containerIpAddress}:${container.mappedPort(port)}/").toURL
   }
 
   private def urlToString(url: URL) = {

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/GenericContainerSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/GenericContainerSpec.scala
@@ -1,12 +1,9 @@
 package com.dimafeng.testcontainers.integration
 
-import java.net.URL
-
+import java.net.URI
 import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.images.builder.ImageFromDockerfile
-import org.testcontainers.images.builder.traits.ClasspathTrait;
 
 import scala.io.Source
 
@@ -18,7 +15,7 @@ class GenericContainerSpec extends AnyFlatSpec with ForAllTestContainer {
 
   "GenericContainer" should "start nginx and expose 80 port" in {
     assert(Source.fromInputStream(
-      new URL(s"http://${container.containerIpAddress}:${container.mappedPort(80)}/").openConnection().getInputStream
+      new URI(s"http://${container.containerIpAddress}:${container.mappedPort(80)}/").toURL.openConnection().getInputStream
     ).mkString.contains("If you see this page, the nginx web server is successfully installed"))
   }
 }


### PR DESCRIPTION
updated to latest versions
```Scala
private val seleniumVersion = "4.8.1"
private val slf4jVersion = "2.0.5"
private val scalaTestVersion = "3.2.15"
private val scalaTestMockitoVersion = "3.2.10.0"
private val mysqlConnectorVersion = "8.0.33"
private val neo4jConnectorVersion = "5.6.0"
private val oracleDriverVersion = "21.9.0.0"
private val cassandraDriverVersion = "4.15.0"
private val postgresqlDriverVersion = "42.5.4"
private val kafkaDriverVersion = "3.4.0"
private val restAssuredVersion = "5.3.1"
private val groovyVersion = "3.0.16"
private val awsV1Version = "1.12.472"
private val awsV2Version = "2.20.68"
private val sttpVersion = "3.8.13"
private val firestoreConnectorVersion = "3.9.1"
private val bigtableVersion = "2.20.0"
private val pubsubVersion = "1.123.6"
```