### PR TITLE
Migrate to Docker Compose v2

### DIFF
--- a/core/src/main/scala/com/dimafeng/testcontainers/DockerComposeContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/DockerComposeContainer.scala
@@ -7,7 +7,7 @@ import java.util.function.Consumer
 import com.dimafeng.testcontainers.DockerComposeContainer.ComposeFile
 import org.testcontainers.containers.output.OutputFrame
 import org.testcontainers.containers.wait.strategy.{Wait, WaitStrategy}
-import org.testcontainers.containers.{ContainerState, DockerComposeContainer => JavaDockerComposeContainer}
+import org.testcontainers.containers.{ContainerState, ComposeContainer => JavaDockerComposeContainer}
 import org.testcontainers.utility.Base58
 
 import scala.collection.JavaConverters._
@@ -131,10 +131,10 @@ class DockerComposeContainer(composeFiles: ComposeFile,
                              logConsumers: Seq[ServiceLogConsumer] = Seq.empty,
                              waitingFor: Option[WaitingForService] = None,
                              services: Services = Services.All)
-  extends TestContainerProxy[JavaDockerComposeContainer[_]] {
+  extends TestContainerProxy[JavaDockerComposeContainer] {
 
-  override val container: JavaDockerComposeContainer[_] = {
-    val container: JavaDockerComposeContainer[_] = new JavaDockerComposeContainer(identifier, composeFiles match {
+  override val container: JavaDockerComposeContainer = {
+    val container: JavaDockerComposeContainer = new JavaDockerComposeContainer(identifier, composeFiles match {
       case ComposeFile(Left(f)) => util.Arrays.asList(f)
       case ComposeFile(Right(files)) => files.asJava
     })
@@ -162,7 +162,6 @@ class DockerComposeContainer(composeFiles: ComposeFile,
 
     container.withPull(pull)
     container.withLocalCompose(localCompose)
-    container.withOptions("--compatibility")
     container.withEnv(env.asJava)
     container.withTailChildContainers(tailChildContainers)
 

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/ComposeWaitingForSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/ComposeWaitingForSpec.scala
@@ -15,7 +15,7 @@ class ComposeWaitingForSpec extends AnyFlatSpec with ForAllTestContainer {
 
   "DockerComposeContainer" should "wait for service" in {
     // container.start() should blocks until successful or timeout
-    assert(container.getContainerByServiceName("redis_1").get.isRunning)
+    assert(container.getContainerByServiceName("redis-1").get.isRunning)
   }
 }
 


### PR DESCRIPTION
This PR requires #259 to get merged first.

Close #200

This PR aims to migrate to the backend of `com.dimafeng.testcontainers.DockerComposeContainer` from Docker Compose V1 (a.k.a `docker-compose`) to the Docker Compose V2 (a.k.a `docker compose`)

See more details at https://github.com/testcontainers/testcontainers-java/pull/5608

> From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.

https://docs.docker.com/compose/migrate/

Compose V1 actually reached EOL, and Compose V2 has been adopted for a long time, so I suppose the change won't break user experience.

Before this PR, `docker-compose` is necessary for launching compose files.
After this PR, all tests passed without `docker-compose` but only `docker` commands