### PR TITLE
Use AWS auth dependency for LocalStack

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -211,8 +211,7 @@ object Dependencies {
     COMPILE(
       "org.testcontainers" % "localstack" % testcontainersVersion
     ) ++ PROVIDED(
-      "software.amazon.awssdk" % "s3" % awsV2Version,
-      "software.amazon.awssdk" % "sqs" % awsV2Version
+      "software.amazon.awssdk" % "auth" % awsV2Version,
     )
   )
 


### PR DESCRIPTION
I believe the error addressed in https://github.com/testcontainers/testcontainers-scala/pull/136 and https://github.com/testcontainers/testcontainers-scala/pull/216 can actually be fixed for all client types if you use the auth dependency directly rather than individual client libraries.

I've tested this locally on a project where I was getting `java.lang.NoClassDefFoundError: com/amazonaws/auth/AWSCredentials` when using secrets-manager and switching to this dependency fixed it.