### PR TITLE
Allow to start Kafka and Schema Registry containers in the same Network

### DIFF
--- a/modules/kafka/src/main/scala/com/dimafeng/testcontainers/KafkaContainer.scala
+++ b/modules/kafka/src/main/scala/com/dimafeng/testcontainers/KafkaContainer.scala
@@ -1,29 +1,34 @@
 package com.dimafeng.testcontainers
 
-import org.testcontainers.containers.{KafkaContainer => JavaKafkaContainer}
+import org.testcontainers.containers.{Network, KafkaContainer => JavaKafkaContainer}
 import org.testcontainers.utility.DockerImageName
 
-case class KafkaContainer(dockerImageName: DockerImageName = DockerImageName.parse(KafkaContainer.defaultDockerImageName)
-                    ) extends SingleContainer[JavaKafkaContainer] {
+case class KafkaContainer(
+  override val network: Network = KafkaContainer.defaultNetwork,
+  dockerImageName: DockerImageName = KafkaContainer.defaultDockerImage
+) extends SingleContainer[JavaKafkaContainer] {
 
-  override val container: JavaKafkaContainer = new JavaKafkaContainer(dockerImageName)
+  override val container: JavaKafkaContainer = new JavaKafkaContainer(dockerImageName).withNetwork(network)
 
   def bootstrapServers: String = container.getBootstrapServers
 }
 
 object KafkaContainer {
 
-  val defaultImage = "confluentinc/cp-kafka"
   val defaultTag = "7.2.0"
-  val defaultDockerImageName = s"$defaultImage:$defaultTag"
 
-  case class Def(dockerImageName: DockerImageName = DockerImageName.parse(KafkaContainer.defaultDockerImageName)
-                ) extends ContainerDef {
+  private val defaultDockerImage = DockerImageName.parse(s"confluentinc/cp-kafka:$defaultTag")
+  private def defaultNetwork: Network = Network.newNetwork()
+
+  case class Def(
+    network: Network = defaultNetwork,
+    dockerImageName: DockerImageName = defaultDockerImage
+  ) extends ContainerDef {
 
     override type Container = KafkaContainer
 
     override def createContainer(): KafkaContainer = {
-      new KafkaContainer(dockerImageName)
+      new KafkaContainer(network, dockerImageName)
     }
   }
 }

--- a/modules/kafka/src/test/scala/com/dimafeng/testcontainers/integration/SchemaRegistrySpec.scala
+++ b/modules/kafka/src/test/scala/com/dimafeng/testcontainers/integration/SchemaRegistrySpec.scala
@@ -16,6 +16,7 @@ class SchemaRegistrySpec extends AnyFlatSpec with ForAllTestContainer with Match
 
   //this should be the same version that your lib is using under the hood
   val kafkaVersion = "6.1.1"
+  val kafkaDockerImage = DockerImageName.parse(s"confluentinc/cp-kafka:$kafkaVersion")
 
   //these are the default kafka host name but because that may change
   //we need to ensure that these are the values for container network, kafka and the schema registry
@@ -27,11 +28,10 @@ class SchemaRegistrySpec extends AnyFlatSpec with ForAllTestContainer with Match
   //a way to communicate containers
   val network: Network = Network.newNetwork()
 
-  val kafkaContainer: KafkaContainer = KafkaContainer.Def(DockerImageName.parse(s"confluentinc/cp-kafka:$kafkaVersion")).createContainer()
+  val kafkaContainer: KafkaContainer = KafkaContainer.Def(network, kafkaDockerImage).createContainer()
   val schemaRegistryContainer: GenericContainer = SchemaRegistryContainer.Def(network, hostName, kafkaVersion).createContainer()
 
   kafkaContainer.container
-    .withNetwork(network)
     .withNetworkAliases(hostName)
     .withEnv(
       Map[String, String](


### PR DESCRIPTION
As a Developer I want to be able to start Kafka and Schema Registry in the same network using public interfaces/constructors.

Now it is impossible for two reasons:
1. starting the Kafka container and invoking its `getNetwork` method results in a `null` response
2. Schema Registry constructor does not allow to provide Network

Example usage

```
  final case class KafkaConfig(bootstrapServers: String, networkAlias: String)
  final case class SchemaRegistryConfig(schemaUrl: String)

  private def kafka(network: Network) =
    Resource
      .make(IO(KafkaContainer.Def(network).start()))(c => IO(c.stop()))
      .map { kafkaContainer =>
        KafkaConfig(kafkaContainer.bootstrapServers, kafkaContainer.networkAliases.head)
      }

  private def schemaRegistry(network: Network, kafkaConfig: KafkaConfig) =
    Resource
      .make(IO(SchemaRegistryContainer.Def(network, kafkaConfig.networkAlias).start()))(c => IO(c.stop()))
      .map { schemaRegistryContainer =>
        SchemaRegistryConfig(schemaRegistryContainer.schemaUrl)
      }

  def kafkaWithSchemaRegistry: Resource[IO, (KafkaConfig, SchemaRegistryConfig)] =
    for
      network <- Resource.fromAutoCloseable(IO(Network.newNetwork()))
      kafkaConfig <- kafka(network)
      schemaRegistryConfig <- schemaRegistry(network, kafkaConfig)
    yield (kafkaConfig, schemaRegistryConfig)
```
