### PR TITLE
fix deprecated annotations, bump sbt version

### DIFF
--- a/core/src/main/scala/com/dimafeng/testcontainers/Container.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/Container.scala
@@ -22,22 +22,22 @@ import org.testcontainers.utility.{MountableFile, ThrowingFunction}
 import scala.collection.JavaConverters._
 import scala.concurrent.{Future, blocking}
 
-@deprecated("For internal usage only. Will be deleted.")
+@deprecated("For internal usage only. Will be deleted.", "v0.34.0")
 trait TestContainerProxy[T <: FailureDetectingExternalResource] extends Container {
 
-  @deprecated("Please use reflective methods from the wrapper and `configure` method for creation")
+  @deprecated("Please use reflective methods from the wrapper and `configure` method for creation", "v0.17.0")
   implicit def container: T
 
-  @deprecated("Use `stop` instead")
+  @deprecated("Use `stop` instead", "v0.27.0")
   override def finished()(implicit description: Description): Unit = TestContainerAccessor.finished(description)
 
-  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
+  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead", "v0.27.0")
   override def succeeded()(implicit description: Description): Unit = TestContainerAccessor.succeeded(description)
 
-  @deprecated("Use `start` instead")
+  @deprecated("Use `start` instead", "v0.27.0")
   override def starting()(implicit description: Description): Unit = TestContainerAccessor.starting(description)
 
-  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
+  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead", "v0.27.0")
   override def failed(e: Throwable)(implicit description: Description): Unit = TestContainerAccessor.failed(e, description)
 }
 
@@ -79,7 +79,7 @@ abstract class SingleContainer[T <: JavaGenericContainer[_]] extends TestContain
     }
   }
 
-  @deprecated("See org.testcontainers.containers.Network")
+  @deprecated("See org.testcontainers.containers.Network", "v0.17.0")
   def linkedContainers: Map[String, LinkableContainer] = container.getLinkedContainers.asScala.toMap
 
   def mappedPort(port: Int): Int = container.getMappedPort(port)
@@ -163,15 +163,15 @@ abstract class SingleContainer[T <: JavaGenericContainer[_]] extends TestContain
 
 trait Container extends Startable with Stoppable {
 
-  @deprecated("Use `stop` instead")
+  @deprecated("Use `stop` instead", "v0.29.0")
   def finished()(implicit description: Description): Unit = stop()
 
-  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
+  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead", "v0.29.0")
   def failed(e: Throwable)(implicit description: Description): Unit = {}
 
-  @deprecated("Use `start` instead")
+  @deprecated("Use `start` instead", "v0.29.0")
   def starting()(implicit description: Description): Unit = start()
 
-  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
+  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead", "v0.29.0")
   def succeeded()(implicit description: Description): Unit = {}
 }

--- a/core/src/main/scala/com/dimafeng/testcontainers/DockerComposeContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/DockerComposeContainer.scala
@@ -50,14 +50,14 @@ object DockerComposeContainer {
 
   def randomIdentifier: String = Base58.randomString(DockerComposeContainer.ID_LENGTH).toLowerCase()
 
-  @deprecated("Please use expanded `apply` method")
+  @deprecated("Please use expanded `apply` method", "v0.19.0")
   def apply(composeFiles: ComposeFile,
             exposedService: Map[String, Int],
             identifier: String): DockerComposeContainer =
     apply(composeFiles, exposedService, identifier)
 
 
-  @deprecated("Please use expanded `apply` method")
+  @deprecated("Please use expanded `apply` method", "v0.19.0")
   def apply(composeFiles: ComposeFile,
             exposedService: Map[String, Int]): DockerComposeContainer =
     new DockerComposeContainer(composeFiles, exposedService)

--- a/core/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala
@@ -8,16 +8,16 @@ import scala.language.implicitConversions
 
 class MultipleContainers private(containers: Seq[LazyContainer[_]]) extends Container with TestLifecycleAware {
 
-  @deprecated("Use `stop` instead")
+  @deprecated("Use `stop` instead", "v0.27.0")
   override def finished()(implicit description: Description): Unit = containers.foreach(_.finished()(description))
 
-  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
+  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead", "v0.27.0")
   override def succeeded()(implicit description: Description): Unit = containers.foreach(_.succeeded()(description))
 
-  @deprecated("Use `start` instead")
+  @deprecated("Use `start` instead", "v0.27.0")
   override def starting()(implicit description: Description): Unit = containers.foreach(_.starting()(description))
 
-  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
+  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead", "v0.27.0")
   override def failed(e: Throwable)(implicit description: Description): Unit = containers.foreach(_.failed(e)(description))
 
   override def beforeTest(description: TestDescription): Unit = {
@@ -68,16 +68,16 @@ object MultipleContainers {
 class LazyContainer[T <: Container](factory: => T) extends Container with TestLifecycleAware {
   lazy val container: T = factory
 
-  @deprecated("Use `stop` instead")
+  @deprecated("Use `stop` instead", "v0.27.0")
   override def finished()(implicit description: Description): Unit = container.finished()
 
-  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
+  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead", "v0.27.0")
   override def failed(e: Throwable)(implicit description: Description): Unit = container.failed(e)
 
-  @deprecated("Use `start` instead")
+  @deprecated("Use `start` instead", "v0.27.0")
   override def starting()(implicit description: Description): Unit = container.starting()
 
-  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
+  @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead", "v0.27.0")
   override def succeeded()(implicit description: Description): Unit = container.succeeded()
 
   override def beforeTest(description: TestDescription): Unit = {

--- a/core/src/main/scala/com/dimafeng/testcontainers/implicits/DockerImageNameConverters.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/implicits/DockerImageNameConverters.scala
@@ -3,7 +3,7 @@ package com.dimafeng.testcontainers.implicits
 import org.testcontainers.utility.DockerImageName
 
 trait DockerImageNameConverters {
-  @deprecated("Use `DockerImageName` in Container constructor instead")
+  @deprecated("Use `DockerImageName` in Container constructor instead", "v0.38.7")
   implicit def stringToDockerImageName(s: String): DockerImageName =
     DockerImageName.parse(s)
 }

--- a/core/src/main/scala/org/testcontainers/containers/TestContainerAccessor.scala
+++ b/core/src/main/scala/org/testcontainers/containers/TestContainerAccessor.scala
@@ -2,7 +2,7 @@ package org.testcontainers.containers
 
 import org.junit.runner.Description
 
-@deprecated("Should be replaced by lifecycle methods")
+@deprecated("Should be replaced by lifecycle methods", "v0.27.0")
 object TestContainerAccessor {
   def finished[T <:FailureDetectingExternalResource](description: Description)(implicit container: T): Unit =
     container.finished(description)

--- a/modules/vault/src/main/scala/com/dimafeng/testcontainers/VaultContainer.scala
+++ b/modules/vault/src/main/scala/com/dimafeng/testcontainers/VaultContainer.scala
@@ -5,7 +5,7 @@ import org.testcontainers.vault.{VaultContainer => JavaVaultContainer}
 
 class VaultContainer(dockerImageNameOverride: Option[DockerImageName] = None,
                      vaultToken: Option[String] = None,
-                     @deprecated vaultPort: Option[Int] = None,
+                     @deprecated("use container's defaults", "v0.39.0") vaultPort: Option[Int] = None,
                      secrets: Option[VaultContainer.Secrets] = None) extends SingleContainer[JavaVaultContainer[_]] {
 
   val vaultContainer: JavaVaultContainer[_] = {
@@ -37,7 +37,7 @@ object VaultContainer {
 
   def apply(dockerImageNameOverride: DockerImageName = null,
             vaultToken: String = null,
-            @deprecated vaultPort: Option[Int] = None,
+            @deprecated("use container's defaults", "v0.39.0") vaultPort: Option[Int] = None,
             secrets: Option[VaultContainer.Secrets] = None): VaultContainer = new VaultContainer(
     Option(dockerImageNameOverride),
     Option(vaultToken),
@@ -48,7 +48,7 @@ object VaultContainer {
   case class Def(
     dockerImageName: DockerImageName = DockerImageName.parse(defaultDockerImageName),
     vaultToken: Option[String] = None,
-    @deprecated vaultPort: Option[Int] = None,
+    @deprecated("use container's defaults", "v0.39.0") vaultPort: Option[Int] = None,
     secrets: Option[VaultContainer.Secrets] = None
   ) extends ContainerDef {
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.0
+sbt.version=1.9.8


### PR DESCRIPTION
- bump sbt version to 1.9.8
- fix `@`deprecated annotations, it should accept two arguments

```scala
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/org/testcontainers/containers/TestContainerAccessor.scala:5:2: @deprecated now takes two arguments; see the scaladoc.
[warn] @deprecated("Should be replaced by lifecycle methods")
[warn]  ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala:11:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `stop` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala:14:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala:17:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `start` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala:20:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala:71:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `stop` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala:74:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala:77:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `start` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala:80:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/DockerComposeContainer.scala:53:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Please use expanded `apply` method")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/DockerComposeContainer.scala:60:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Please use expanded `apply` method")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/Container.scala:25:2: @deprecated now takes two arguments; see the scaladoc.
[warn] @deprecated("For internal usage only. Will be deleted.")
[warn]  ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/Container.scala:28:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Please use reflective methods from the wrapper and `configure` method for creation")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/Container.scala:31:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `stop` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/Container.scala:34:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/Container.scala:37:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `start` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/Container.scala:40:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/Container.scala:82:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("See org.testcontainers.containers.Network")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/Container.scala:166:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `stop` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/Container.scala:169:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/Container.scala:172:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `start` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/Container.scala:175:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `stop` and/or `TestLifecycleAware.afterTest` instead")
[warn]    ^
[warn] /Users/roman/git/github.com/testcontainers-scala/core/src/main/scala/com/dimafeng/testcontainers/implicits/DockerImageNameConverters.scala:6:4: @deprecated now takes two arguments; see the scaladoc.
[warn]   @deprecated("Use `DockerImageName` in Container constructor instead")
[warn]  

[warn] /Users/roman/git/github.com/testcontainers-scala/modules/vault/src/main/scala/com/dimafeng/testcontainers/VaultContainer.scala:8:23: @deprecated now takes two arguments; see the scaladoc.
[warn]                      @deprecated vaultPort: Option[Int] = None,
[warn]                       ^
[warn] /Users/roman/git/github.com/testcontainers-scala/modules/vault/src/main/scala/com/dimafeng/testcontainers/VaultContainer.scala:40:14: @deprecated now takes two arguments; see the scaladoc.
[warn]             @deprecated vaultPort: Option[Int] = None,
[warn]              ^
[warn] /Users/roman/git/github.com/testcontainers-scala/modules/vault/src/main/scala/com/dimafeng/testcontainers/VaultContainer.scala:51:6: @deprecated now takes two arguments; see the scaladoc.
[warn]     @deprecated vaultPort: Option[Int] = None,
[warn]      ^
```