### PR TITLE
minor updates for LocalStackV2Container

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -381,7 +381,7 @@ lazy val moduleLocalstack = (project in file("modules/localstack"))
   )
 
 lazy val moduleLocalstackV2 = (project in file("modules/localstackV2"))
-  .dependsOn(core % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided", scalatest % "test->test")
   .settings(commonSettings)
   .settings(
     name := "testcontainers-scala-localstack-v2",

--- a/modules/localstackV2/src/main/scala/com/dimafeng/testcontainers/LocalStackV2Container.scala
+++ b/modules/localstackV2/src/main/scala/com/dimafeng/testcontainers/LocalStackV2Container.scala
@@ -2,16 +2,17 @@ package com.dimafeng.testcontainers
 
 import java.net.URI
 import org.testcontainers.containers.localstack.{LocalStackContainer => JavaLocalStackContainer}
+import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.regions.Region
 
 case class LocalStackV2Container(
-  tag: String = LocalStackV2Container.defaultTag,
-  services: Seq[LocalStackV2Container.Service] = Seq.empty
+    tag: String = LocalStackV2Container.defaultTag,
+    services: Seq[LocalStackV2Container.Service] = Seq.empty
 ) extends SingleContainer[JavaLocalStackContainer] {
 
   override val container: JavaLocalStackContainer = {
-    val c = new JavaLocalStackContainer(tag)
+    val c = new JavaLocalStackContainer(DockerImageName.parse(LocalStackV2Container.defaultImage + ":" + tag))
     c.withServices(services: _*)
     c
   }
@@ -28,15 +29,14 @@ case class LocalStackV2Container(
 }
 
 object LocalStackV2Container {
-
-
-  val defaultTag = "0.12.12"
+  val defaultImage: String = "localstack/localstack"
+  val defaultTag: String = "0.12.12"
 
   type Service = JavaLocalStackContainer.EnabledService
 
   case class Def(
-                  tag: String = LocalStackV2Container.defaultTag,
-                  services: Seq[LocalStackV2Container.Service] = Seq.empty
+      tag: String = LocalStackV2Container.defaultTag,
+      services: Seq[LocalStackV2Container.Service] = Seq.empty
   ) extends ContainerDef {
 
     override type Container = LocalStackV2Container

--- a/modules/localstackV2/src/test/scala/com/dimafeng/testcontainers/LocalStackV2Spec.scala
+++ b/modules/localstackV2/src/test/scala/com/dimafeng/testcontainers/LocalStackV2Spec.scala
@@ -1,0 +1,42 @@
+package com.dimafeng.testcontainers
+
+import com.dimafeng.testcontainers.scalatest.TestContainersForAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.testcontainers.containers.localstack.LocalStackContainer.Service.S3
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+
+class LocalStackV2Spec extends AnyFlatSpec with TestContainersForAll {
+  override type Containers = LocalStackV2Container
+
+  override def startContainers(): LocalStackV2Container =
+    LocalStackV2Container
+      .Def(services = Seq(S3))
+      .start()
+
+  "LocalStackV2 container" should "be started" in withContainers {
+    localStackContainer =>
+      val s3: S3Client = S3Client
+        .builder()
+        .endpointOverride(localStackContainer.endpointOverride(S3))
+        .credentialsProvider(localStackContainer.staticCredentialsProvider)
+        .region(localStackContainer.region)
+        .build()
+
+      LocalStackV2Spec.createBucket(s3, "testcontainers-bucket")
+
+      assert(s3.listBuckets().buckets().size() == 1)
+  }
+}
+
+object LocalStackV2Spec {
+  def createBucket(s3: S3Client, bucketName: String): Unit = {
+    val request = CreateBucketRequest
+      .builder()
+      .bucket(bucketName)
+      .build()
+
+    s3.createBucket(request)
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,14 +1,14 @@
-import sbt._
+import sbt.*
 import sbt.Keys.scalaVersion
 
 object Dependencies {
-  private def COMPILE(modules: sbt.ModuleID*): Seq[sbt.ModuleID] = deps(None, modules: _*)
+  private def COMPILE(modules: ModuleID*): Seq[ModuleID] = deps(None, modules: _*)
 
-  private def PROVIDED(modules: sbt.ModuleID*): Seq[sbt.ModuleID] = deps(Some("provided"), modules: _*)
+  private def PROVIDED(modules: ModuleID*): Seq[ModuleID] = deps(Some(Provided), modules: _*)
 
-  private def TEST(modules: sbt.ModuleID*): Seq[sbt.ModuleID] = deps(Some("test"), modules: _*)
+  private def TEST(modules: ModuleID*): Seq[ModuleID] = deps(Some(Test), modules: _*)
 
-  private def deps(scope: Option[String], modules: sbt.ModuleID*): Seq[sbt.ModuleID] = {
+  private def deps(scope: Option[Configuration], modules: sbt.ModuleID*): Seq[ModuleID] = {
     scope.map(s => modules.map(_ % s)).getOrElse(modules)
   }
 
@@ -31,7 +31,7 @@ object Dependencies {
   private val restAssuredVersion = "4.0.0"
   private val groovyVersion = "2.5.16"
   private val awsV1Version = "1.11.479"
-  private val awsV2Version = "2.17.158"
+  private val awsV2Version = "2.20.68"
   private val sttpVersion = "3.3.14"
   private val firestoreConnectorVersion = "3.0.11"
   private val bigtableVersion = "2.5.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
 
   private def TEST(modules: ModuleID*): Seq[ModuleID] = deps(Some(Test), modules: _*)
 
-  private def deps(scope: Option[Configuration], modules: sbt.ModuleID*): Seq[ModuleID] = {
+  private def deps(scope: Option[Configuration], modules: ModuleID*): Seq[ModuleID] = {
     scope.map(s => modules.map(_ % s)).getOrElse(modules)
   }
 


### PR DESCRIPTION
- fixed deprecation warning

```scala
[warn] testcontainers-scala/modules/localstackV2/src/main/scala/com/dimafeng/testcontainers/LocalStackV2Container.scala:14:13: constructor LocalStackContainer in class LocalStackContainer is deprecated: see corresponding Javadoc for more information.
[warn]     val c = new JavaLocalStackContainer(tag)
[warn]             ^
[warn] one warning found
```

- added basic unit test for LocalStackV2 container
- changed a bit arguments signature in helper methods for dependencies
- bump aws-toolkit v2 version