### PR TITLE
Add unit tests and `serverHost` to MockServerContainer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -397,7 +397,7 @@ lazy val moduleMariadb = (project in file("modules/mariadb"))
   )
 
 lazy val moduleMockserver = (project in file("modules/mockserver"))
-  .dependsOn(core % "compile->compile;test->test;provided->provided")
+  .dependsOn(core % "compile->compile;test->test;provided->provided", scalatest % "test->test")
   .settings(commonSettings)
   .settings(
     name := "testcontainers-scala-mockserver",

--- a/modules/mockserver/src/main/scala/com/dimafeng/testcontainers/MockServerContainer.scala
+++ b/modules/mockserver/src/main/scala/com/dimafeng/testcontainers/MockServerContainer.scala
@@ -7,7 +7,7 @@ case class MockServerContainer(
   version: String = MockServerContainer.defaultVersion
 ) extends SingleContainer[JavaMockServerContainer] {
 
-  override val container: JavaMockServerContainer = 
+  override val container: JavaMockServerContainer =
     new JavaMockServerContainer(
       MockServerContainer.defaultImageName.withTag(s"mockserver-$version")
     )
@@ -15,6 +15,8 @@ case class MockServerContainer(
   def endpoint: String = container.getEndpoint
 
   def serverPort: Int = container.getServerPort
+
+  def serverHost: String = container.getHost
 }
 
 object MockServerContainer {

--- a/modules/mockserver/src/test/scala/com/dimafeng/testcontainers/MockServerSpec.scala
+++ b/modules/mockserver/src/test/scala/com/dimafeng/testcontainers/MockServerSpec.scala
@@ -5,11 +5,13 @@ import org.mockserver.client.MockServerClient
 import org.mockserver.model.HttpRequest.request
 import org.mockserver.model.HttpResponse.response
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-import org.scalatest.matchers.should.Matchers.not.be
-import sttp.client3.{UriContext, basicRequest}
+import org.scalatest.matchers.should.Matchers
+import sttp.client3.{HttpURLConnectionBackend, UriContext, basicRequest}
 
-class MockServerSpec extends AnyFlatSpec with TestContainersForAll {
+class MockServerSpec
+    extends AnyFlatSpec
+    with TestContainersForAll
+    with Matchers {
   override type Containers = MockServerContainer
 
   override def startContainers(): MockServerContainer =
@@ -17,23 +19,20 @@ class MockServerSpec extends AnyFlatSpec with TestContainersForAll {
 
   "MockServer container" should "be started" in withContainers {
     mockServerContainer =>
+      val backend = HttpURLConnectionBackend()
+
       val mockServerClient = new MockServerClient(
         mockServerContainer.serverHost,
         mockServerContainer.serverPort
       )
 
       mockServerClient
-        .when(
-          request()
-            .withMethod("GET")
-            .withPath("/hello")
-        )
-        .respond(
-          response.withBody("world")
-        )
+        .when(request("/hello"))
+        .respond(response("world"))
 
       basicRequest
         .get(uri"${mockServerContainer.endpoint}/hello")
+        .send(backend)
         .body should be(Right("world"))
   }
 }

--- a/modules/mockserver/src/test/scala/com/dimafeng/testcontainers/MockServerSpec.scala
+++ b/modules/mockserver/src/test/scala/com/dimafeng/testcontainers/MockServerSpec.scala
@@ -1,0 +1,39 @@
+package com.dimafeng.testcontainers
+
+import com.dimafeng.testcontainers.scalatest.TestContainersForAll
+import org.mockserver.client.MockServerClient
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.matchers.should.Matchers.not.be
+import sttp.client3.{UriContext, basicRequest}
+
+class MockServerSpec extends AnyFlatSpec with TestContainersForAll {
+  override type Containers = MockServerContainer
+
+  override def startContainers(): MockServerContainer =
+    MockServerContainer.Def().start()
+
+  "MockServer container" should "be started" in withContainers {
+    mockServerContainer =>
+      val mockServerClient = new MockServerClient(
+        mockServerContainer.serverHost,
+        mockServerContainer.serverPort
+      )
+
+      mockServerClient
+        .when(
+          request()
+            .withMethod("GET")
+            .withPath("/hello")
+        )
+        .respond(
+          response.withBody("world")
+        )
+
+      basicRequest
+        .get(uri"${mockServerContainer.endpoint}/hello")
+        .body should be(Right("world"))
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -227,6 +227,9 @@ object Dependencies {
   val moduleMockserver = Def.setting(
     COMPILE(
       "org.testcontainers" % "mockserver" % testcontainersVersion
+    ) ++ TEST(
+      "com.softwaremill.sttp.client3" %% "core" % sttpVersion,
+      "org.mock-server" % "mockserver-client-java" % "5.13.2"
     )
   )
 


### PR DESCRIPTION
- add unit test for testcontainers-scala-mockserver 
- Add a `serverHost` method to the MockServerContainer for easier usage with MockServerClient