### PR TITLE
add "Free space" step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # Container modules occupy too much disk space. The GitHub-hosted runners ran into the
+      # error: "no space left on device."
+      # This action will free up disk space by removing unnecessary files.
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        if: runner.os == 'Linux'
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
       - name: Setup Java
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
This will fix the "no space left" error on GitHub Actions runners encountered in #273 and #272:

```
System.IO.IOException: No space left on device: '/home/runner/runners/2.312.0/_diag/Worker_20240210-081954-utc.log'
```

The fix is inspired by the CI configuration in [testcontainers-dotnet](https://github.com/testcontainers/testcontainers-dotnet/blob/develop/.github/workflows/cicd.yml#L48-L64).

The CI configuration was tested in the [forked repository](https://github.com/greshny-forks/testcontainers-scala/pull/2), where CI runs took 2-3 minutes longer.

Result output is:

```
/dev/root:

********************************************************************************
=> Saved 32GiB
********************************************************************************

overall:

********************************************************************************
=> Saved 32GiB
********************************************************************************

```


