### PR TITLE
fix deprecation warning for PostgreSQLContainer

### DIFF
--- a/modules/postgres/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala
+++ b/modules/postgres/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala
@@ -13,13 +13,11 @@ class PostgreSQLContainer(
   commonJdbcParams: JdbcDatabaseContainer.CommonParams = JdbcDatabaseContainer.CommonParams()
 ) extends SingleContainer[JavaPostgreSQLContainer[_]] with JdbcDatabaseContainer {
 
+  import PostgreSQLContainer._
+
   override val container: JavaPostgreSQLContainer[_] = {
-    val c: JavaPostgreSQLContainer[_] = dockerImageNameOverride match {
-      case Some(imageNameOverride) =>
-        new JavaPostgreSQLContainer(imageNameOverride)
-      case None =>
-        new JavaPostgreSQLContainer()
-    }
+    val dockerImageName = dockerImageNameOverride.getOrElse(parsedDockerImageName)
+    val c: JavaPostgreSQLContainer[_] = new JavaPostgreSQLContainer(dockerImageName)
 
     databaseName.foreach(c.withDatabaseName)
     pgUsername.foreach(c.withUsername)
@@ -53,6 +51,9 @@ object PostgreSQLContainer {
   val defaultUsername = "test"
   val defaultPassword = "test"
 
+  private[testcontainers] def parsedDockerImageName: DockerImageName =
+    DockerImageName.parse(defaultDockerImageName)
+
   def apply(
     dockerImageNameOverride: DockerImageName = null,
     databaseName: String = null,
@@ -69,7 +70,7 @@ object PostgreSQLContainer {
     )
 
   case class Def(
-    dockerImageName: DockerImageName = DockerImageName.parse(defaultDockerImageName),
+    dockerImageName: DockerImageName = parsedDockerImageName,
     databaseName: String = defaultDatabaseName,
     username: String = defaultUsername,
     password: String = defaultPassword,


### PR DESCRIPTION
fixes:

```scala
[info] compiling 1 Scala source to /Users/roman/git/github.com/testcontainers-scala/modules/postgres/target/scala-3.1.2/classes ...
[warn] -- Deprecation Warning: /Users/roman/git/github.com/testcontainers-scala/modules/postgres/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala:21:12 
[warn] 21 |        new JavaPostgreSQLContainer()
[warn]    |            ^^^^^^^^^^^^^^^^^^^^^^^
[warn]    |constructor PostgreSQLContainer in class PostgreSQLContainer is deprecated since : see corresponding Javadoc for more information.
[warn] one warning found
```