### PR TITLE
Add Def pattern for FixedHostPortGenericContainer and seq port bindings

### DIFF
--- a/core/src/main/scala/com/dimafeng/testcontainers/FixedHostPortGenericContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/FixedHostPortGenericContainer.scala
@@ -3,7 +3,7 @@ package com.dimafeng.testcontainers
 import com.dimafeng.testcontainers.GenericContainer.FileSystemBind
 import org.testcontainers.containers.startupcheck.StartupCheckStrategy
 import org.testcontainers.containers.wait.strategy.WaitStrategy
-import org.testcontainers.containers.{BindMode, FixedHostPortGenericContainer => JavaFixedHostPortGenericContainer}
+import org.testcontainers.containers.{FixedHostPortGenericContainer => JavaFixedHostPortGenericContainer}
 
 class FixedHostPortGenericContainer(imageName: String,
                                     exposedPorts: Seq[Int] = Seq(),
@@ -11,10 +11,9 @@ class FixedHostPortGenericContainer(imageName: String,
                                     command: Seq[String] = Seq(),
                                     classpathResourceMapping: Seq[FileSystemBind] = Seq(),
                                     waitStrategy: Option[WaitStrategy] = None,
-                                    exposedHostPort: Int,
-                                    exposedContainerPort: Int,
                                     fileSystemBind: Seq[FileSystemBind] = Seq(),
-                                    startupCheckStrategy: Option[StartupCheckStrategy] = None
+                                    startupCheckStrategy: Option[StartupCheckStrategy] = None,
+                                    portBindings: Seq[(Int, Int)] = Seq()
                                    ) extends SingleContainer[JavaFixedHostPortGenericContainer[_]] {
 
   override implicit val container: JavaFixedHostPortGenericContainer[_] = new JavaFixedHostPortGenericContainer(imageName)
@@ -22,7 +21,7 @@ class FixedHostPortGenericContainer(imageName: String,
   if (exposedPorts.nonEmpty) {
     container.withExposedPorts(exposedPorts.map(int2Integer): _*)
   }
-  env.foreach{ case (k, v) => container.withEnv(k, v) }
+  env.foreach { case (k, v) => container.withEnv(k, v) }
   if (command.nonEmpty) {
     container.withCommand(command: _*)
   }
@@ -36,21 +35,47 @@ class FixedHostPortGenericContainer(imageName: String,
   }
   waitStrategy.foreach(container.waitingFor)
   startupCheckStrategy.foreach(container.withStartupCheckStrategy)
-  container.withFixedExposedPort(exposedHostPort, exposedContainerPort)
+  portBindings.foreach { case (hostPort, containerPort) => container.withFixedExposedPort(hostPort, containerPort) }
 }
 
 object FixedHostPortGenericContainer {
+
+  case class Def(imageName: String,
+                 exposedPorts: Seq[Int] = Seq(),
+                 env: Map[String, String] = Map(),
+                 command: Seq[String] = Seq(),
+                 classpathResourceMapping: Seq[FileSystemBind] = Seq(),
+                 waitStrategy: Option[WaitStrategy] = None,
+                 fileSystemBind: Seq[FileSystemBind] = Seq(),
+                 startupCheckStrategy: Option[StartupCheckStrategy] = None,
+                 portBindings: Seq[(Int, Int)]
+                ) extends ContainerDef {
+    override type Container = FixedHostPortGenericContainer
+
+    override protected def createContainer(): FixedHostPortGenericContainer =
+      new FixedHostPortGenericContainer(
+        imageName = imageName,
+        exposedPorts = exposedPorts,
+        env = env,
+        command = command,
+        classpathResourceMapping = classpathResourceMapping,
+        waitStrategy = waitStrategy,
+        fileSystemBind = fileSystemBind,
+        startupCheckStrategy = startupCheckStrategy,
+        portBindings = portBindings
+      )
+  }
+
   def apply(
-    imageName: String,
-    exposedPorts: Seq[Int] = Seq(),
-    env: Map[String, String] = Map(),
-    command: Seq[String] = Seq(),
-    classpathResourceMapping: Seq[FileSystemBind] = Seq(),
-    waitStrategy: WaitStrategy = null,
-    exposedHostPort: Int,
-    exposedContainerPort: Int,
-    fileSystemBind: Seq[FileSystemBind] = Seq()
-  ): FixedHostPortGenericContainer=
+             imageName: String,
+             exposedPorts: Seq[Int] = Seq(),
+             env: Map[String, String] = Map(),
+             command: Seq[String] = Seq(),
+             classpathResourceMapping: Seq[FileSystemBind] = Seq(),
+             waitStrategy: WaitStrategy = null,
+             fileSystemBind: Seq[FileSystemBind] = Seq(),
+             portBindings: Seq[(Int, Int)] = Seq()
+           ): FixedHostPortGenericContainer =
     new FixedHostPortGenericContainer(
       imageName = imageName,
       exposedPorts = exposedPorts,
@@ -59,7 +84,6 @@ object FixedHostPortGenericContainer {
       classpathResourceMapping = classpathResourceMapping,
       fileSystemBind = fileSystemBind,
       waitStrategy = Option(waitStrategy),
-      exposedHostPort = exposedHostPort,
-      exposedContainerPort = exposedContainerPort
+      portBindings = portBindings
     )
 }

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/FixedHostPortContainerSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/FixedHostPortContainerSpec.scala
@@ -11,8 +11,7 @@ import scala.io.Source
 class FixedHostPortContainerSpec extends AnyFlatSpec with ForAllTestContainer {
   override val container: FixedHostPortGenericContainer = FixedHostPortGenericContainer("nginx:latest",
     waitStrategy = new HttpWaitStrategy().forPath("/"),
-    exposedHostPort = 8090,
-    exposedContainerPort = 80
+    portBindings = Seq((8090, 80))
   )
 
   "FixedHostPortGenericContainer" should "start nginx and expose 8090 port on host" in {


### PR DESCRIPTION
* add Def pattern for FixedHostPortGenericContainer
* make fixed port declaration via Seq. This allows containers with more than one port to be raised. For example https://github.com/Grokzen/docker-redis-cluster

This is done because there are difficulties with colima on mac os and testcontainers and there is a need to run the redis-cluster container on all fixed ports

Welcome to suggestions