### PR TITLE
Remove redundant params in MilvusContainer

### DIFF
--- a/modules/milvus/src/main/scala/com/dimafeng/testcontainers/MilvusContainer.scala
+++ b/modules/milvus/src/main/scala/com/dimafeng/testcontainers/MilvusContainer.scala
@@ -4,14 +4,12 @@ import org.testcontainers.milvus.{MilvusContainer => JavaMilvusIOContainer}
 import org.testcontainers.utility.DockerImageName
 
 case class MilvusContainer(
-                            dockerImageName: DockerImageName = DockerImageName.parse(MilvusContainer.defaultDockerImageName),
-                            httpPort: Int = MilvusContainer.defaultPort,
-                            etcdEndpoint: Option[String] = None
+    dockerImageName: DockerImageName = DockerImageName.parse(MilvusContainer.defaultDockerImageName),
+    etcdEndpoint: Option[String] = None
 ) extends SingleContainer[JavaMilvusIOContainer] {
 
   override val container: JavaMilvusIOContainer = {
     val c = new JavaMilvusIOContainer(dockerImageName)
-    c.withExposedPorts(httpPort, MilvusContainer.managementPort)
     etcdEndpoint.foreach(c.withEtcdEndpoint)
     c
   }
@@ -21,19 +19,18 @@ case class MilvusContainer(
 
 object MilvusContainer {
 
-  val defaultImage = "milvusdb/milvus"
-  val defaultTag = "v2.4.4"
+  val defaultImage           = "milvusdb/milvus"
+  val defaultTag             = "v2.4.4"
   val defaultDockerImageName = s"$defaultImage:$defaultTag"
 
-  val defaultPort = 19530
-  val managementPort = 9091
-
-  case class Def(dockerImageName: DockerImageName = DockerImageName.parse(MilvusContainer.defaultDockerImageName),
-    port: Int = MilvusContainer.defaultPort) extends ContainerDef {
+  case class Def(
+      dockerImageName: DockerImageName = DockerImageName.parse(MilvusContainer.defaultDockerImageName),
+      etcdEndpoint: Option[String] = None
+  ) extends ContainerDef {
     override type Container = MilvusContainer
 
     override def createContainer(): MilvusContainer = {
-      new MilvusContainer(dockerImageName, port)
+      new MilvusContainer(dockerImageName, etcdEndpoint)
     }
   }
 }


### PR DESCRIPTION
Remove exposing ports, since this is done in the underlying container.