### PR TITLE
Update localstack to 4.0.3

### DIFF
--- a/modules/localstack/src/main/scala/com/dimafeng/testcontainers/LocalStackContainer.scala
+++ b/modules/localstack/src/main/scala/com/dimafeng/testcontainers/LocalStackContainer.scala
@@ -18,7 +18,7 @@ case class LocalStackContainer(
 object LocalStackContainer {
 
   val defaultImage = "localstack/localstack"
-  val defaultTag = "0.12.12"
+  val defaultTag = "4.0.3"
   val defaultDockerImageName = s"$defaultImage:$defaultTag"
 
   type Service = JavaLocalStackContainer.Service

--- a/modules/localstackV2/src/main/scala/com/dimafeng/testcontainers/LocalStackV2Container.scala
+++ b/modules/localstackV2/src/main/scala/com/dimafeng/testcontainers/LocalStackV2Container.scala
@@ -30,7 +30,7 @@ case class LocalStackV2Container(
 
 object LocalStackV2Container {
   val defaultImage: String = "localstack/localstack"
-  val defaultTag: String = "0.12.12"
+  val defaultTag: String = "4.0.3"
 
   type Service = JavaLocalStackContainer.EnabledService
 


### PR DESCRIPTION
Hi, excellent repo!

This updates localstack to the latest version on dockerhub.

The trigger for this was so I can use the newer localstack docker images built for arm64.