### PR TITLE
replace to new wildcard syntax

### DIFF
--- a/core/src/main/scala/com/dimafeng/testcontainers/Container.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/Container.scala
@@ -41,7 +41,7 @@ trait TestContainerProxy[T <: FailureDetectingExternalResource] extends Containe
   override def failed(e: Throwable)(implicit description: Description): Unit = TestContainerAccessor.failed(e, description)
 }
 
-abstract class SingleContainer[T <: JavaGenericContainer[_]] extends TestContainerProxy[T] {
+abstract class SingleContainer[T <: JavaGenericContainer[?]] extends TestContainerProxy[T] {
 
   def underlyingUnsafeContainer: T = container
 

--- a/core/src/main/scala/com/dimafeng/testcontainers/FixedHostPortGenericContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/FixedHostPortGenericContainer.scala
@@ -14,9 +14,9 @@ class FixedHostPortGenericContainer(imageName: String,
                                     fileSystemBind: Seq[FileSystemBind] = Seq(),
                                     startupCheckStrategy: Option[StartupCheckStrategy] = None,
                                     portBindings: Seq[(Int, Int)] = Seq()
-                                   ) extends SingleContainer[JavaFixedHostPortGenericContainer[_]] {
+                                   ) extends SingleContainer[JavaFixedHostPortGenericContainer[?]] {
 
-  override implicit val container: JavaFixedHostPortGenericContainer[_] = new JavaFixedHostPortGenericContainer(imageName)
+  override implicit val container: JavaFixedHostPortGenericContainer[?] = new JavaFixedHostPortGenericContainer(imageName)
 
   if (exposedPorts.nonEmpty) {
     container.withExposedPorts(exposedPorts.map(int2Integer): _*)

--- a/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/GenericContainer.scala
@@ -11,10 +11,10 @@ import org.testcontainers.images.ImagePullPolicy
 import scala.collection.JavaConverters._
 
 class GenericContainer(
-  override val underlyingUnsafeContainer: JavaGenericContainer[_]
-) extends SingleContainer[JavaGenericContainer[_]] {
+  override val underlyingUnsafeContainer: JavaGenericContainer[?]
+) extends SingleContainer[JavaGenericContainer[?]] {
 
-  override implicit val container: JavaGenericContainer[_] = underlyingUnsafeContainer
+  override implicit val container: JavaGenericContainer[?] = underlyingUnsafeContainer
 
   def this(
     dockerImage: DockerImage,
@@ -29,7 +29,7 @@ class GenericContainer(
     fileSystemBind: Seq[FileSystemBind] = Seq(),
     startupCheckStrategy: Option[StartupCheckStrategy] = None
   ) = this({
-    val underlying: JavaGenericContainer[_] = dockerImage match {
+    val underlying: JavaGenericContainer[?] = dockerImage match {
       case DockerImage(Left(imageFromDockerfile)) => new JavaGenericContainer(imageFromDockerfile)
       case DockerImage(Right(imageName))          => new JavaGenericContainer(imageName)
     }

--- a/core/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala
+++ b/core/src/main/scala/com/dimafeng/testcontainers/MultipleContainers.scala
@@ -6,7 +6,7 @@ import org.testcontainers.lifecycle.TestDescription
 
 import scala.language.implicitConversions
 
-class MultipleContainers private(containers: Seq[LazyContainer[_]]) extends Container with TestLifecycleAware {
+class MultipleContainers private(containers: Seq[LazyContainer[?]]) extends Container with TestLifecycleAware {
 
   @deprecated("Use `stop` instead", "v0.27.0")
   override def finished()(implicit description: Description): Unit = containers.foreach(_.finished()(description))
@@ -54,7 +54,7 @@ object MultipleContainers {
     *  val containers = MultipleContainers(pgContainer, appContainer)
     *  }}}
     */
-  def apply(containers: LazyContainer[_]*): MultipleContainers = new MultipleContainers(containers)
+  def apply(containers: LazyContainer[?]*): MultipleContainers = new MultipleContainers(containers)
 }
 
 /**

--- a/modules/cassandra/src/main/scala/com/dimafeng/testcontainers/CassandraContainer.scala
+++ b/modules/cassandra/src/main/scala/com/dimafeng/testcontainers/CassandraContainer.scala
@@ -7,9 +7,9 @@ import org.testcontainers.utility.DockerImageName
 class CassandraContainer(dockerImageNameOverride: Option[DockerImageName] = None,
                          configurationOverride: Option[String] = None,
                          initScript: Option[String] = None,
-                         jmxReporting: Boolean = false) extends SingleContainer[JavaCassandraContainer[_]] {
+                         jmxReporting: Boolean = false) extends SingleContainer[JavaCassandraContainer[?]] {
 
-  val cassandraContainer: JavaCassandraContainer[_] = {
+  val cassandraContainer: JavaCassandraContainer[?] = {
     if (dockerImageNameOverride.isEmpty) {
       new JavaCassandraContainer()
     } else {
@@ -21,7 +21,7 @@ class CassandraContainer(dockerImageNameOverride: Option[DockerImageName] = None
   if (initScript.isDefined) cassandraContainer.withInitScript(initScript.get)
   if (jmxReporting) cassandraContainer.withJmxReporting(jmxReporting)
 
-  override val container: JavaCassandraContainer[_] = cassandraContainer
+  override val container: JavaCassandraContainer[?] = cassandraContainer
 
   def cluster: Cluster = cassandraContainer.getCluster
 

--- a/modules/influxdb/src/main/scala/com/dimafeng/testcontainers/InfluxDBContainer.scala
+++ b/modules/influxdb/src/main/scala/com/dimafeng/testcontainers/InfluxDBContainer.scala
@@ -11,10 +11,10 @@ case class InfluxDBContainer(
   username: String = InfluxDBContainer.defaultUsername,
   password: String = InfluxDBContainer.defaultPassword,
   authEnabled: Boolean = InfluxDBContainer.defaultAuthEnabled
-) extends SingleContainer[JavaInfluxDBContainer[_]] {
+) extends SingleContainer[JavaInfluxDBContainer[?]] {
 
-  override val container: JavaInfluxDBContainer[_] = {
-    val c: JavaInfluxDBContainer[_] = new JavaInfluxDBContainer(tag)
+  override val container: JavaInfluxDBContainer[?] = {
+    val c: JavaInfluxDBContainer[?] = new JavaInfluxDBContainer(tag)
     c.withDatabase(database)
     c.withAdmin(admin)
     c.withAdminPassword(adminPassword)

--- a/modules/jdbc/src/main/scala/com/dimafeng/testcontainers/JdbcDatabaseContainer.scala
+++ b/modules/jdbc/src/main/scala/com/dimafeng/testcontainers/JdbcDatabaseContainer.scala
@@ -6,7 +6,7 @@ import org.testcontainers.containers.{JdbcDatabaseContainer => JavaJdbcDatabaseC
 
 import scala.concurrent.duration._
 
-trait JdbcDatabaseContainer { self: SingleContainer[_ <: JavaJdbcDatabaseContainer[_]] =>
+trait JdbcDatabaseContainer { self: SingleContainer[? <: JavaJdbcDatabaseContainer[?]] =>
 
   def driverClassName: String = underlyingUnsafeContainer.getDriverClassName
 
@@ -27,7 +27,7 @@ object JdbcDatabaseContainer {
     connectTimeout: FiniteDuration = 120.seconds,
     initScriptPath: Option[String] = None
   ) {
-    private[testcontainers] def applyTo[C <: JavaJdbcDatabaseContainer[_]](container: C): Unit = {
+    private[testcontainers] def applyTo[C <: JavaJdbcDatabaseContainer[?]](container: C): Unit = {
       container.withStartupTimeoutSeconds(startupTimeout.toSeconds.toInt)
       container.withConnectTimeoutSeconds(connectTimeout.toSeconds.toInt)
       initScriptPath.foreach(container.withInitScript)

--- a/modules/mariadb/src/main/scala/com/dimafeng/testcontainers/MariaDBContainer.scala
+++ b/modules/mariadb/src/main/scala/com/dimafeng/testcontainers/MariaDBContainer.scala
@@ -11,10 +11,10 @@ case class MariaDBContainer(
   configurationOverride: Option[String] = None,
   urlParams: Map[String, String] = Map.empty,
   commonJdbcParams: JdbcDatabaseContainer.CommonParams = JdbcDatabaseContainer.CommonParams()
-) extends SingleContainer[JavaMariaDBContainer[_]] with JdbcDatabaseContainer {
+) extends SingleContainer[JavaMariaDBContainer[?]] with JdbcDatabaseContainer {
 
-  override val container: JavaMariaDBContainer[_] = {
-    val c: JavaMariaDBContainer[_] = new JavaMariaDBContainer(dockerImageName)
+  override val container: JavaMariaDBContainer[?] = {
+    val c: JavaMariaDBContainer[?] = new JavaMariaDBContainer(dockerImageName)
 
     c.withDatabaseName(dbName)
     c.withUsername(dbUsername)

--- a/modules/mssqlserver/src/main/scala/com/dimafeng/testcontainers/MSSQLServerContainer.scala
+++ b/modules/mssqlserver/src/main/scala/com/dimafeng/testcontainers/MSSQLServerContainer.scala
@@ -10,10 +10,10 @@ case class MSSQLServerContainer(
   dbPassword: String = MSSQLServerContainer.defaultPassword,
   urlParams: Map[String, String] = Map.empty,
   commonJdbcParams: JdbcDatabaseContainer.CommonParams = MSSQLServerContainer.defaultCommonJdbcParams
-) extends SingleContainer[JavaMSSQLServerContainer[_]] with JdbcDatabaseContainer {
+) extends SingleContainer[JavaMSSQLServerContainer[?]] with JdbcDatabaseContainer {
 
-  override val container: JavaMSSQLServerContainer[_] = {
-    val c: JavaMSSQLServerContainer[_] = new JavaMSSQLServerContainer(dockerImageName)
+  override val container: JavaMSSQLServerContainer[?] = {
+    val c: JavaMSSQLServerContainer[?] = new JavaMSSQLServerContainer(dockerImageName)
 
     c.withPassword(dbPassword)
     urlParams.foreach { case (key, value) =>

--- a/modules/mysql/src/main/scala/com/dimafeng/testcontainers/MySQLContainer.scala
+++ b/modules/mysql/src/main/scala/com/dimafeng/testcontainers/MySQLContainer.scala
@@ -11,10 +11,10 @@ class MySQLContainer(
   mysqlPassword: Option[String] = None,
   urlParams: Map[String, String] = Map.empty,
   commonJdbcParams: JdbcDatabaseContainer.CommonParams = JdbcDatabaseContainer.CommonParams()
-) extends SingleContainer[JavaMySQLContainer[_]] with JdbcDatabaseContainer {
+) extends SingleContainer[JavaMySQLContainer[?]] with JdbcDatabaseContainer {
 
-  override val container: JavaMySQLContainer[_] = {
-    val c: JavaMySQLContainer[_] = mysqlImageVersion
+  override val container: JavaMySQLContainer[?] = {
+    val c: JavaMySQLContainer[?] = mysqlImageVersion
       .map(new JavaMySQLContainer(_))
       .getOrElse(new JavaMySQLContainer(MySQLContainer.DEFAULT_MYSQL_VERSION))
 

--- a/modules/neo4j/src/main/scala/com/dimafeng/testcontainers/Neo4jContainer.scala
+++ b/modules/neo4j/src/main/scala/com/dimafeng/testcontainers/Neo4jContainer.scala
@@ -6,9 +6,9 @@ import org.testcontainers.utility.DockerImageName
 class Neo4jContainer(configurationOverride: Option[String] = None,
                      neo4jImageVersion: Option[DockerImageName] = None,
                      neo4jPassword: Option[String] = None)
-  extends SingleContainer[JavaNeo4jContainer[_]] {
+  extends SingleContainer[JavaNeo4jContainer[?]] {
 
-  override val container: JavaNeo4jContainer[_] = neo4jImageVersion
+  override val container: JavaNeo4jContainer[?] = neo4jImageVersion
     .map(new JavaNeo4jContainer(_))
     .getOrElse(new JavaNeo4jContainer(Neo4jContainer.DEFAULT_NEO4J_VERSION))
 

--- a/modules/nginx/src/main/scala/com/dimafeng/testcontainers/NginxContainer.scala
+++ b/modules/nginx/src/main/scala/com/dimafeng/testcontainers/NginxContainer.scala
@@ -6,10 +6,10 @@ import org.testcontainers.containers.{NginxContainer => JavaNginxContainer}
 
 case class NginxContainer(
   customContent: Option[String] = None
-) extends SingleContainer[JavaNginxContainer[_]] {
+) extends SingleContainer[JavaNginxContainer[?]] {
 
-  override val container: JavaNginxContainer[_] = {
-    val c: JavaNginxContainer[_] = new JavaNginxContainer()
+  override val container: JavaNginxContainer[?] = {
+    val c: JavaNginxContainer[?] = new JavaNginxContainer()
     customContent.foreach(c.withCustomContent)
     c
   }

--- a/modules/postgres/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala
+++ b/modules/postgres/src/main/scala/com/dimafeng/testcontainers/PostgreSQLContainer.scala
@@ -11,13 +11,13 @@ class PostgreSQLContainer(
   mountPostgresDataToTmpfs: Boolean = false,
   urlParams: Map[String, String] = Map.empty,
   commonJdbcParams: JdbcDatabaseContainer.CommonParams = JdbcDatabaseContainer.CommonParams()
-) extends SingleContainer[JavaPostgreSQLContainer[_]] with JdbcDatabaseContainer {
+) extends SingleContainer[JavaPostgreSQLContainer[?]] with JdbcDatabaseContainer {
 
   import PostgreSQLContainer._
 
-  override val container: JavaPostgreSQLContainer[_] = {
+  override val container: JavaPostgreSQLContainer[?] = {
     val dockerImageName = dockerImageNameOverride.getOrElse(parsedDockerImageName)
-    val c: JavaPostgreSQLContainer[_] = new JavaPostgreSQLContainer(dockerImageName)
+    val c: JavaPostgreSQLContainer[?] = new JavaPostgreSQLContainer(dockerImageName)
 
     databaseName.foreach(c.withDatabaseName)
     pgUsername.foreach(c.withUsername)

--- a/modules/presto/src/main/scala/com/dimafeng/testcontainers/PrestoContainer.scala
+++ b/modules/presto/src/main/scala/com/dimafeng/testcontainers/PrestoContainer.scala
@@ -10,10 +10,10 @@ case class PrestoContainer(
   dbUsername: String = PrestoContainer.defaultDbUsername,
   dbName: String = PrestoContainer.defaultDbName,
   commonJdbcParams: JdbcDatabaseContainer.CommonParams = JdbcDatabaseContainer.CommonParams()
-) extends SingleContainer[JavaPrestoContainer[_]] with JdbcDatabaseContainer {
+) extends SingleContainer[JavaPrestoContainer[?]] with JdbcDatabaseContainer {
 
-  override val container: JavaPrestoContainer[_] = {
-    val c: JavaPrestoContainer[_] = new JavaPrestoContainer(dockerImageName)
+  override val container: JavaPrestoContainer[?] = {
+    val c: JavaPrestoContainer[?] = new JavaPrestoContainer(dockerImageName)
     c.withUsername(dbUsername)
     c.withDatabaseName(dbName)
     commonJdbcParams.applyTo(c)

--- a/modules/toxiproxy/src/main/scala/com/dimafeng/testcontainers/ToxiproxyContainer.scala
+++ b/modules/toxiproxy/src/main/scala/com/dimafeng/testcontainers/ToxiproxyContainer.scala
@@ -13,7 +13,7 @@ case class ToxiproxyContainer(
 
   def proxy(hostname: String, port: Int): ContainerProxy = container.getProxy(hostname, port)
 
-  def proxy(container: SingleContainer[_], port: Int): ContainerProxy = proxy(container.networkAliases.head, port)
+  def proxy(container: SingleContainer[?], port: Int): ContainerProxy = proxy(container.networkAliases.head, port)
 }
 
 object ToxiproxyContainer {

--- a/modules/vault/src/main/scala/com/dimafeng/testcontainers/VaultContainer.scala
+++ b/modules/vault/src/main/scala/com/dimafeng/testcontainers/VaultContainer.scala
@@ -6,9 +6,9 @@ import org.testcontainers.vault.{VaultContainer => JavaVaultContainer}
 class VaultContainer(dockerImageNameOverride: Option[DockerImageName] = None,
                      vaultToken: Option[String] = None,
                      @deprecated("use container's defaults", "v0.39.0") vaultPort: Option[Int] = None,
-                     secrets: Option[VaultContainer.Secrets] = None) extends SingleContainer[JavaVaultContainer[_]] {
+                     secrets: Option[VaultContainer.Secrets] = None) extends SingleContainer[JavaVaultContainer[?]] {
 
-  val vaultContainer: JavaVaultContainer[_] = {
+  val vaultContainer: JavaVaultContainer[?] = {
     if (dockerImageNameOverride.isEmpty) {
       new JavaVaultContainer()
     } else {
@@ -22,7 +22,7 @@ class VaultContainer(dockerImageNameOverride: Option[DockerImageName] = None,
     vaultContainer.withSecretInVault(x.path, x.firstSecret, x.secrets: _*)
   }
 
-  override val container: JavaVaultContainer[_] = vaultContainer
+  override val container: JavaVaultContainer[?] = vaultContainer
 }
 
 object VaultContainer {

--- a/test-framework/munit/src/test/scala/com/dimafeng/testcontainers/munit/fixtures/ForAllTestContainersFixtureSpec.scala
+++ b/test-framework/munit/src/test/scala/com/dimafeng/testcontainers/munit/fixtures/ForAllTestContainersFixtureSpec.scala
@@ -59,14 +59,14 @@ object ForAllTestContainersFixtureSpec {
 
   protected class TestSpec(testBody: => Unit, container: Container) extends ContainerSpec {
     val containerFixture = ForAllContainerFixture(container)
-    override def munitFixtures: Seq[Fixture[_]] = List(containerFixture)
+    override def munitFixtures: Seq[Fixture[?]] = List(containerFixture)
 
     test("test") {testBody}
   }
 
   protected class MultipleTestsSpec(testBody: => Unit, container: Container) extends ContainerSpec {
     val containerFixture = ForAllContainerFixture(container)
-    override def munitFixtures: Seq[Fixture[_]] = List(containerFixture)
+    override def munitFixtures: Seq[Fixture[?]] = List(containerFixture)
 
     test("test1") {testBody}
     test("test2") {testBody}

--- a/test-framework/munit/src/test/scala/com/dimafeng/testcontainers/munit/fixtures/ForEachTestContainersFixtureSpec.scala
+++ b/test-framework/munit/src/test/scala/com/dimafeng/testcontainers/munit/fixtures/ForEachTestContainersFixtureSpec.scala
@@ -60,7 +60,7 @@ object ForEachTestContainersFixtureSpec {
   protected class TestSpec(testBody: => Unit, container: Container) extends ContainerSpec {
     val containerFixture = ForEachContainerFixture(container)
 
-    override def munitFixtures: Seq[Fixture[_]] = List(containerFixture)
+    override def munitFixtures: Seq[Fixture[?]] = List(containerFixture)
 
     test("test") {testBody}
   }
@@ -68,7 +68,7 @@ object ForEachTestContainersFixtureSpec {
   protected class MultipleTestsSpec(testBody: => Unit, container: Container) extends ContainerSpec {
     val containerFixture = ForEachContainerFixture(container)
 
-    override def munitFixtures: Seq[Fixture[_]] = List(containerFixture)
+    override def munitFixtures: Seq[Fixture[?]] = List(containerFixture)
 
     test("test1") {testBody}
     test("test2") {testBody}

--- a/test-framework/scalatest-selenium/src/main/scala/com/dimafeng/testcontainers/SeleniumTestContainerSuite.scala
+++ b/test-framework/scalatest-selenium/src/main/scala/com/dimafeng/testcontainers/SeleniumTestContainerSuite.scala
@@ -25,10 +25,10 @@ trait SeleniumTestContainerSuite extends ForEachTestContainer {
 
 class SeleniumContainer(desiredCapabilities: Option[DesiredCapabilities] = None,
                         recordingMode: Option[(BrowserWebDriverContainer.VncRecordingMode, File)] = None)
-  extends SingleContainer[BrowserWebDriverContainer[_]] with TestLifecycleAware {
+  extends SingleContainer[BrowserWebDriverContainer[?]] with TestLifecycleAware {
   require(desiredCapabilities.isDefined, "'desiredCapabilities' is required parameter")
 
-  override val container: BrowserWebDriverContainer[_] = new BrowserWebDriverContainer()
+  override val container: BrowserWebDriverContainer[?] = new BrowserWebDriverContainer()
   desiredCapabilities.foreach(container.withDesiredCapabilities)
   recordingMode.foreach { case (recMode, recDir) => container.withRecordingMode(recMode, recDir) }
 

--- a/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/GenericContainerDefSpec.scala
+++ b/test-framework/scalatest/src/test/scala/com/dimafeng/testcontainers/integration/GenericContainerDefSpec.scala
@@ -35,7 +35,7 @@ object GenericContainerDefSpec {
 
   private val port = 80
 
-  private def createUrl(container: SingleContainer[_]) = {
+  private def createUrl(container: SingleContainer[?]) = {
     new URL(s"http://${container.containerIpAddress}:${container.mappedPort(port)}/")
   }
 


### PR DESCRIPTION

old wildcard syntax `[_]` is deprecated in latest Scala 3.

```
Welcome to Scala 3.6.3 (21.0.5, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                           
scala> val a: List[_] = Nil
1 warning found
-- Warning: --------------------------------------------------------------------
1 |val a: List[_] = Nil
  |            ^
  |        `_` is deprecated for wildcard arguments of types: use `?` instead
val a: List[?] = List()
                                                                                                                                           
scala> val b: List[?] = Nil
val b: List[?] = List()
```