### PR TITLE
Bump SBT 1.10.7 and update sbt script

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -17,8 +17,7 @@ jobs:
           distribution: temurin
           java-version: 8
           cache: sbt
-      - uses: sbt/setup-sbt@v1
-      - run: sbt ci-release
+      - run: ./sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,6 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: "sbt"
-      - uses: sbt/setup-sbt@v1
-        with:
-          sbt-runner-version: 1.10.5
       - name: Restore cache
         uses: actions/cache@v2
         with:
@@ -58,4 +55,4 @@ jobs:
           restore-keys: |
             cache-v1-
       - name: Compile and Test
-        run: sbt +test
+        run: ./sbt +test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.5
+sbt.version=1.10.7

--- a/sbt
+++ b/sbt
@@ -1,578 +1,851 @@
 #!/usr/bin/env bash
-#
-# A more capable sbt runner, coincidentally also called sbt.
-# Author: Paul Phillips <paulp@improving.org>
 
-set -o pipefail
+set +e
+declare builtin_sbt_version="1.10.7"
+declare -a residual_args
+declare -a java_args
+declare -a scalac_args
+declare -a sbt_commands
+declare -a sbt_options
+declare -a print_version
+declare -a print_sbt_version
+declare -a print_sbt_script_version
+declare -a shutdownall
+declare -a original_args
+declare java_cmd=java
+declare java_version
+declare init_sbt_version=_to_be_replaced
+declare sbt_default_mem=1024
+declare -r default_sbt_opts=""
+declare -r default_java_opts="-Dfile.encoding=UTF-8"
+declare sbt_verbose=
+declare sbt_debug=
+declare build_props_sbt_version=
+declare use_sbtn=
+declare no_server=
+declare sbtn_command="$SBTN_CMD"
+declare sbtn_version="1.10.5"
+declare use_colors=1
 
-declare -r sbt_release_version="0.13.16"
-declare -r sbt_unreleased_version="0.13.16"
+###  ------------------------------- ###
+###  Helper methods for BASH scripts ###
+###  ------------------------------- ###
 
-declare -r latest_213="2.13.0-M2"
-declare -r latest_212="2.12.4"
-declare -r latest_211="2.11.12"
-declare -r latest_210="2.10.7"
-declare -r latest_29="2.9.3"
-declare -r latest_28="2.8.2"
+# Bash reimplementation of realpath to return the absolute path
+realpathish () {
+(
+  TARGET_FILE="$1"
+  FIX_CYGPATH="$2"
 
-declare -r buildProps="project/build.properties"
+  cd "$(dirname "$TARGET_FILE")"
+  TARGET_FILE=$(basename "$TARGET_FILE")
 
-declare -r sbt_launch_ivy_release_repo="http://repo.typesafe.com/typesafe/ivy-releases"
-declare -r sbt_launch_ivy_snapshot_repo="https://repo.scala-sbt.org/scalasbt/ivy-snapshots"
-declare -r sbt_launch_mvn_release_repo="http://repo.scala-sbt.org/scalasbt/maven-releases"
-declare -r sbt_launch_mvn_snapshot_repo="http://repo.scala-sbt.org/scalasbt/maven-snapshots"
+  COUNT=0
+  while [ -L "$TARGET_FILE" -a $COUNT -lt 100 ]
+  do
+    TARGET_FILE=$(readlink "$TARGET_FILE")
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE=$(basename "$TARGET_FILE")
+    COUNT=$(($COUNT + 1))
+  done
 
-declare -r default_jvm_opts_common="-Xms512m -Xmx1536m -Xss2m"
-declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
-
-declare sbt_jar sbt_dir sbt_create sbt_version sbt_script sbt_new
-declare sbt_explicit_version
-declare verbose noshare batch trace_level
-declare debugUs
-
-declare java_cmd="java"
-declare sbt_launch_dir="$HOME/.sbt/launchers"
-declare sbt_launch_repo
-
-# pull -J and -D options to give to java.
-declare -a java_args scalac_args sbt_commands residual_args
-
-# args to jvm/sbt via files or environment variables
-declare -a extra_jvm_opts extra_sbt_opts
-
-echoerr () { echo >&2 "$@"; }
-vlog ()    { [[ -n "$verbose" ]] && echoerr "$@"; }
-die ()     { echo "Aborting: $@" ; exit 1; }
-
-setTrapExit () {
-  # save stty and trap exit, to ensure echo is re-enabled if we are interrupted.
-  export SBT_STTY="$(stty -g 2>/dev/null)"
-
-  # restore stty settings (echo in particular)
-  onSbtRunnerExit() {
-    [ -t 0 ] || return
-    vlog ""
-    vlog "restoring stty: $SBT_STTY"
-    stty "$SBT_STTY"
-  }
-
-  vlog "saving stty: $SBT_STTY"
-  trap onSbtRunnerExit EXIT
-}
-
-# this seems to cover the bases on OSX, and someone will
-# have to tell me about the others.
-get_script_path () {
-  local path="$1"
-  [[ -L "$path" ]] || { echo "$path" ; return; }
-
-  local target="$(readlink "$path")"
-  if [[ "${target:0:1}" == "/" ]]; then
-    echo "$target"
+  TARGET_DIR="$(pwd -P)"
+  if [ "$TARGET_DIR" == "/" ]; then
+    TARGET_FILE="/$TARGET_FILE"
   else
-    echo "${path%/*}/$target"
+    TARGET_FILE="$TARGET_DIR/$TARGET_FILE"
   fi
-}
 
-declare -r script_path="$(get_script_path "$BASH_SOURCE")"
-declare -r script_name="${script_path##*/}"
-
-init_default_option_file () {
-  local overriding_var="${!1}"
-  local default_file="$2"
-  if [[ ! -r "$default_file" && "$overriding_var" =~ ^@(.*)$ ]]; then
-    local envvar_file="${BASH_REMATCH[1]}"
-    if [[ -r "$envvar_file" ]]; then
-      default_file="$envvar_file"
-    fi
+  # make sure we grab the actual windows path, instead of cygwin's path.
+  if [[ "x$FIX_CYGPATH" != "x" ]]; then
+    echo "$(cygwinpath "$TARGET_FILE")"
+  else
+    echo "$TARGET_FILE"
   fi
-  echo "$default_file"
+)
 }
 
-declare sbt_opts_file="$(init_default_option_file SBT_OPTS .sbtopts)"
-declare jvm_opts_file="$(init_default_option_file JVM_OPTS .jvmopts)"
-
-build_props_sbt () {
-  [[ -r "$buildProps" ]] && \
-    grep '^sbt\.version' "$buildProps" | tr '=\r' ' ' | awk '{ print $2; }'
-}
-
-update_build_props_sbt () {
-  local ver="$1"
-  local old="$(build_props_sbt)"
-
-  [[ -r "$buildProps" ]] && [[ "$ver" != "$old" ]] && {
-    perl -pi -e "s/^sbt\.version\b.*\$/sbt.version=${ver}/" "$buildProps"
-    grep -q '^sbt.version[ =]' "$buildProps" || printf "\nsbt.version=%s\n" "$ver" >> "$buildProps"
-
-    vlog "!!!"
-    vlog "!!! Updated file $buildProps setting sbt.version to: $ver"
-    vlog "!!! Previous value was: $old"
-    vlog "!!!"
-  }
-}
-
-set_sbt_version () {
-  sbt_version="${sbt_explicit_version:-$(build_props_sbt)}"
-  [[ -n "$sbt_version" ]] || sbt_version=$sbt_release_version
-  export sbt_version
-}
-
-url_base () {
-  local version="$1"
-
-  case "$version" in
-        0.7.*) echo "http://simple-build-tool.googlecode.com" ;;
-      0.10.* ) echo "$sbt_launch_ivy_release_repo" ;;
-    0.11.[12]) echo "$sbt_launch_ivy_release_repo" ;;
-    0.*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]) # ie "*-yyyymmdd-hhMMss"
-               echo "$sbt_launch_ivy_snapshot_repo" ;;
-          0.*) echo "$sbt_launch_ivy_release_repo" ;;
-    *-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]) # ie "*-yyyymmdd-hhMMss"
-               echo "$sbt_launch_mvn_snapshot_repo" ;;
-            *) echo "$sbt_launch_mvn_release_repo" ;;
+# Uses uname to detect if we're in the odd cygwin environment.
+is_cygwin() {
+  local os=$(uname -s)
+  case "$os" in
+    CYGWIN*) return 0 ;;
+    MINGW*) return 0 ;;
+    MSYS*) return 0 ;;
+    *)  return 1 ;;
   esac
 }
 
-make_url () {
-  local version="$1"
+# TODO - Use nicer bash-isms here.
+CYGWIN_FLAG=$(if is_cygwin; then echo true; else echo false; fi)
 
-  local base="${sbt_launch_repo:-$(url_base "$version")}"
-
-  case "$version" in
-        0.7.*) echo "$base/files/sbt-launch-0.7.7.jar" ;;
-      0.10.* ) echo "$base/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
-    0.11.[12]) echo "$base/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
-          0.*) echo "$base/org.scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
-            *) echo "$base/org/scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
-  esac
-}
-
-addJava ()     { vlog "[addJava] arg = '$1'"   ;     java_args+=("$1"); }
-addSbt ()      { vlog "[addSbt] arg = '$1'"    ;  sbt_commands+=("$1"); }
-addScalac ()   { vlog "[addScalac] arg = '$1'" ;   scalac_args+=("$1"); }
-addResidual () { vlog "[residual] arg = '$1'"  ; residual_args+=("$1"); }
-
-addResolver () { addSbt "set resolvers += $1"; }
-addDebugger () { addJava "-Xdebug" ; addJava "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$1"; }
-setThisBuild () {
-  vlog "[addBuild] args = '$@'"
-  local key="$1" && shift
-  addSbt "set $key in ThisBuild := $@"
-}
-setScalaVersion () {
-  [[ "$1" == *"-SNAPSHOT" ]] && addResolver 'Resolver.sonatypeRepo("snapshots")'
-  addSbt "++ $1"
-}
-setJavaHome () {
-  java_cmd="$1/bin/java"
-  setThisBuild javaHome "_root_.scala.Some(file(\"$1\"))"
-  export JAVA_HOME="$1"
-  export JDK_HOME="$1"
-  export PATH="$JAVA_HOME/bin:$PATH"
-}
-
-getJavaVersion() { "$1" -version 2>&1 | grep -E -e '(java|openjdk) version' | awk '{ print $3 }' | tr -d \"; }
-
-checkJava() {
-  # Warn if there is a Java version mismatch between PATH and JAVA_HOME/JDK_HOME
-
-  [[ -n "$JAVA_HOME" && -e "$JAVA_HOME/bin/java"     ]] && java="$JAVA_HOME/bin/java"
-  [[ -n "$JDK_HOME"  && -e "$JDK_HOME/lib/tools.jar" ]] && java="$JDK_HOME/bin/java"
-
-  if [[ -n "$java" ]]; then
-    pathJavaVersion=$(getJavaVersion java)
-    homeJavaVersion=$(getJavaVersion "$java")
-    if [[ "$pathJavaVersion" != "$homeJavaVersion" ]]; then
-      echoerr "Warning: Java version mismatch between PATH and JAVA_HOME/JDK_HOME, sbt will use the one in PATH"
-      echoerr "  Either: fix your PATH, remove JAVA_HOME/JDK_HOME or use -java-home"
-      echoerr "  java version from PATH:               $pathJavaVersion"
-      echoerr "  java version from JAVA_HOME/JDK_HOME: $homeJavaVersion"
-    fi
-  fi
-}
-
-java_version () {
-  local version=$(getJavaVersion "$java_cmd")
-  vlog "Detected Java version: $version"
-  echo "${version:2:1}"
-}
-
-# MaxPermSize critical on pre-8 JVMs but incurs noisy warning on 8+
-default_jvm_opts () {
-  local v="$(java_version)"
-  if [[ $v -ge 8 ]]; then
-    echo "$default_jvm_opts_common"
+# This can fix cygwin style /cygdrive paths so we get the
+# windows style paths.
+cygwinpath() {
+  local file="$1"
+  if [[ "$CYGWIN_FLAG" == "true" ]]; then #"
+    echo $(cygpath -w $file)
   else
-    echo "-XX:MaxPermSize=384m $default_jvm_opts_common"
+    echo $file
   fi
 }
 
-build_props_scala () {
-  if [[ -r "$buildProps" ]]; then
-    versionLine="$(grep '^build.scala.versions' "$buildProps")"
-    versionString="${versionLine##build.scala.versions=}"
-    echo "${versionString%% .*}"
-  fi
+# Trim leading and trailing spaces from a string.
+# Echos the new trimmed string.
+trimString() {
+  local inputStr="$*"
+  local modStr="${inputStr#"${inputStr%%[![:space:]]*}"}"
+  modStr="${modStr%"${modStr##*[![:space:]]}"}"
+  echo "$modStr"
 }
 
-execRunner () {
-  # print the arguments one to a line, quoting any containing spaces
-  vlog "# Executing command line:" && {
-    for arg; do
-      if [[ -n "$arg" ]]; then
-        if printf "%s\n" "$arg" | grep -q ' '; then
-          printf >&2 "\"%s\"\n" "$arg"
-        else
-          printf >&2 "%s\n" "$arg"
-        fi
-      fi
-    done
-    vlog ""
-  }
+declare -r sbt_bin_dir="$(dirname "$(realpathish "$0")")"
+declare -r sbt_home="$(dirname "$sbt_bin_dir")"
 
-  setTrapExit
-
-  if [[ -n "$batch" ]]; then
-    "$@" < /dev/null
+echoerr () {
+  echo 1>&2 "$@"
+}
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+echoerr_error () {
+  if [[ $use_colors == "1" ]]; then
+    echoerr -e "[${RED}error${NC}] $@"
   else
-    "$@"
+    echoerr "[error] $@"
   fi
 }
-
-jar_url ()  { make_url "$1"; }
-
-is_cygwin () [[ "$(uname -a)" == "CYGWIN"* ]]
+vlog () {
+  [[ $sbt_verbose || $sbt_debug ]] && echoerr "$@"
+}
+dlog () {
+  [[ $sbt_debug ]] && echoerr "$@"
+}
 
 jar_file () {
-  is_cygwin \
-  && echo "$(cygpath -w $sbt_launch_dir/"$1"/sbt-launch.jar)" \
-  || echo "$sbt_launch_dir/$1/sbt-launch.jar"
+  echo "$(cygwinpath "${sbt_home}/bin/sbt-launch.jar")"
+}
+
+jar_url () {
+  local repo_base="$SBT_LAUNCH_REPO"
+  if [[ $repo_base == "" ]]; then
+    repo_base="https://repo1.maven.org/maven2"
+  fi
+  echo "$repo_base/org/scala-sbt/sbt-launch/$1/sbt-launch-$1.jar"
 }
 
 download_url () {
   local url="$1"
   local jar="$2"
-
-  echoerr "Downloading sbt launcher for $sbt_version:"
-  echoerr "  From  $url"
-  echoerr "    To  $jar"
-
-  mkdir -p "${jar%/*}" && {
-    if which curl >/dev/null; then
-      curl --fail --silent --location "$url" --output "$jar"
-    elif which wget >/dev/null; then
-      wget -q -O "$jar" "$url"
+  mkdir -p $(dirname "$jar") && {
+    if command -v curl > /dev/null; then
+      curl --silent -L "$url" --output "$jar"
+    elif command -v wget > /dev/null; then
+      wget --quiet -O "$jar" "$url"
     fi
-  } && [[ -r "$jar" ]]
+  } && [[ -f "$jar" ]]
 }
 
 acquire_sbt_jar () {
-  {
-    sbt_jar="$(jar_file "$sbt_version")"
-    [[ -r "$sbt_jar" ]]
-  } || {
-    sbt_jar="$HOME/.ivy2/local/org.scala-sbt/sbt-launch/$sbt_version/jars/sbt-launch.jar"
-    [[ -r "$sbt_jar" ]]
-  } || {
-    sbt_jar="$(jar_file "$sbt_version")"
-    download_url "$(make_url "$sbt_version")" "$sbt_jar"
+  local launcher_sv="$1"
+  if [[ "$launcher_sv" == "" ]]; then
+    if [[ "$init_sbt_version" != "_to_be_replaced" ]]; then
+      launcher_sv="$init_sbt_version"
+    else
+      launcher_sv="$builtin_sbt_version"
+    fi
+  fi
+  local user_home && user_home=$(findProperty user.home)
+  download_jar="${user_home:-$HOME}/.cache/sbt/boot/sbt-launch/$launcher_sv/sbt-launch-$launcher_sv.jar"
+  if [[ -f "$download_jar" ]]; then
+    sbt_jar="$download_jar"
+  else
+    sbt_url=$(jar_url "$launcher_sv")
+    echoerr "downloading sbt launcher $launcher_sv"
+    download_url "$sbt_url" "${download_jar}.temp"
+    download_url "${sbt_url}.sha1" "${download_jar}.sha1"
+    if command -v shasum > /dev/null; then
+      if echo "$(cat "${download_jar}.sha1")  ${download_jar}.temp" | shasum -c - > /dev/null; then
+        mv "${download_jar}.temp" "${download_jar}"
+      else
+        echoerr "failed to download launcher jar: $sbt_url (shasum mismatch)"
+        exit 2
+      fi
+    else
+      mv "${download_jar}.temp" "${download_jar}"
+    fi
+    if [[ -f "$download_jar" ]]; then
+      sbt_jar="$download_jar"
+    else
+      echoerr "failed to download launcher jar: $sbt_url"
+      exit 2
+    fi
+  fi
+}
+
+acquire_sbtn () {
+  local sbtn_v="$1"
+  local user_home && user_home=$(findProperty user.home)
+  local p="${user_home:-$HOME}/.cache/sbt/boot/sbtn/$sbtn_v"
+  local target="$p/sbtn"
+  local archive_target=
+  local url=
+  local arch="x86_64"
+  if [[ "$OSTYPE" == "linux"* ]]; then
+    arch=$(uname -m)
+    if [[ "$arch" == "aarch64" ]] || [[ "$arch" == "x86_64" ]]; then
+      archive_target="$p/sbtn-${arch}-pc-linux-${sbtn_v}.tar.gz"
+      url="https://github.com/sbt/sbtn-dist/releases/download/v${sbtn_v}/sbtn-${arch}-pc-linux-${sbtn_v}.tar.gz"
+    else
+      echoerr "sbtn is not supported on $arch"
+      exit 2
+    fi
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    archive_target="$p/sbtn-universal-apple-darwin-${sbtn_v}.tar.gz"
+    url="https://github.com/sbt/sbtn-dist/releases/download/v${sbtn_v}/sbtn-universal-apple-darwin-${sbtn_v}.tar.gz"
+  elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
+    target="$p/sbtn.exe"
+    archive_target="$p/sbtn-x86_64-pc-win32-${sbtn_v}.zip"
+    url="https://github.com/sbt/sbtn-dist/releases/download/v${sbtn_v}/sbtn-x86_64-pc-win32-${sbtn_v}.zip"
+  else
+    echoerr "sbtn is not supported on $OSTYPE"
+    exit 2
+  fi
+
+  if [[ -f "$target" ]]; then
+    sbtn_command="$target"
+  else
+    echoerr "downloading sbtn ${sbtn_v} for ${arch}"
+    download_url "$url" "$archive_target"
+    if [[ "$OSTYPE" == "linux-gnu"* ]] || [[ "$OSTYPE" == "darwin"* ]]; then
+      tar zxf "$archive_target" --directory "$p"
+    else
+      unzip "$archive_target" -d "$p"
+    fi
+    sbtn_command="$target"
+  fi
+}
+
+# execRunner should be called only once to give up control to java
+execRunner () {
+  # print the arguments one to a line, quoting any containing spaces
+  [[ $sbt_verbose || $sbt_debug ]] && echo "# Executing command line:" && {
+    for arg; do
+      if printf "%s\n" "$arg" | grep -q ' '; then
+        printf "\"%s\"\n" "$arg"
+      else
+        printf "%s\n" "$arg"
+      fi
+    done
+    echo ""
+  }
+
+  if [[ "$CYGWIN_FLAG" == "true" ]]; then
+    # In cygwin we loose the ability to re-hook stty if exec is used
+    # https://github.com/sbt/sbt-launcher-package/issues/53
+    "$@"
+  else
+    exec "$@"
+  fi
+}
+
+addJava () {
+  dlog "[addJava] arg = '$1'"
+  java_args=( "${java_args[@]}" "$1" )
+}
+addSbt () {
+  dlog "[addSbt] arg = '$1'"
+  sbt_commands=( "${sbt_commands[@]}" "$1" )
+}
+addResidual () {
+  dlog "[residual] arg = '$1'"
+  residual_args=( "${residual_args[@]}" "$1" )
+}
+addDebugger () {
+  addJava "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$1"
+}
+
+addMemory () {
+  dlog "[addMemory] arg = '$1'"
+  # evict memory related options
+  local xs=("${java_args[@]}")
+  java_args=()
+  for i in "${xs[@]}"; do
+    if ! [[ "${i}" == *-Xmx* ]] && ! [[ "${i}" == *-Xms* ]] && ! [[ "${i}" == *-Xss* ]] && ! [[ "${i}" == *-XX:MaxPermSize* ]] && ! [[ "${i}" == *-XX:MaxMetaspaceSize* ]] && ! [[ "${i}" == *-XX:ReservedCodeCacheSize* ]]; then
+      java_args+=("${i}")
+    fi
+  done
+  local ys=("${sbt_options[@]}")
+  sbt_options=()
+  for i in "${ys[@]}"; do
+    if ! [[ "${i}" == *-Xmx* ]] && ! [[ "${i}" == *-Xms* ]] && ! [[ "${i}" == *-Xss* ]] && ! [[ "${i}" == *-XX:MaxPermSize* ]] && ! [[ "${i}" == *-XX:MaxMetaspaceSize* ]] && ! [[ "${i}" == *-XX:ReservedCodeCacheSize* ]]; then
+      sbt_options+=("${i}")
+    fi
+  done
+  # a ham-fisted attempt to move some memory settings in concert
+  local mem=$1
+  local codecache=$(( $mem / 8 ))
+  (( $codecache > 128 )) || codecache=128
+  (( $codecache < 512 )) || codecache=512
+  local class_metadata_size=$(( $codecache * 2 ))
+  if [[ -z $java_version ]]; then
+      java_version=$(jdk_version)
+  fi
+
+  addJava "-Xms${mem}m"
+  addJava "-Xmx${mem}m"
+  addJava "-Xss4M"
+  addJava "-XX:ReservedCodeCacheSize=${codecache}m"
+  (( $java_version >= 8 )) || addJava "-XX:MaxPermSize=${class_metadata_size}m"
+}
+
+addDefaultMemory() {
+  # if we detect any of these settings in ${JAVA_OPTS} or ${JAVA_TOOL_OPTIONS} we need to NOT output our settings.
+  # The reason is the Xms/Xmx, if they don't line up, cause errors.
+  if [[ "${java_args[@]}" == *-Xmx* ]] || \
+     [[ "${java_args[@]}" == *-Xms* ]] || \
+     [[ "${java_args[@]}" == *-Xss* ]] || \
+     [[ "${java_args[@]}" == *-XX:+UseCGroupMemoryLimitForHeap* ]] || \
+     [[ "${java_args[@]}" == *-XX:MaxRAM* ]] || \
+     [[ "${java_args[@]}" == *-XX:InitialRAMPercentage* ]] || \
+     [[ "${java_args[@]}" == *-XX:MaxRAMPercentage* ]] || \
+     [[ "${java_args[@]}" == *-XX:MinRAMPercentage* ]]; then
+    :
+  elif [[ "${JAVA_TOOL_OPTIONS}" == *-Xmx* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-Xms* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-Xss* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-XX:+UseCGroupMemoryLimitForHeap* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-XX:MaxRAM* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-XX:InitialRAMPercentage* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-XX:MaxRAMPercentage* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-XX:MinRAMPercentage* ]] ; then
+    :
+  elif [[ "${sbt_options[@]}" == *-Xmx* ]] || \
+       [[ "${sbt_options[@]}" == *-Xms* ]] || \
+       [[ "${sbt_options[@]}" == *-Xss* ]] || \
+       [[ "${sbt_options[@]}" == *-XX:+UseCGroupMemoryLimitForHeap* ]] || \
+       [[ "${sbt_options[@]}" == *-XX:MaxRAM* ]] || \
+       [[ "${sbt_options[@]}" == *-XX:InitialRAMPercentage* ]] || \
+       [[ "${sbt_options[@]}" == *-XX:MaxRAMPercentage* ]] || \
+       [[ "${sbt_options[@]}" == *-XX:MinRAMPercentage* ]] ; then
+    :
+  else
+    addMemory $sbt_default_mem
+  fi
+}
+
+addSbtScriptProperty () {
+  if [[ "${java_args[@]}" == *-Dsbt.script=* ]]; then
+    :
+  else
+    sbt_script=$0
+    # Use // to replace all spaces with %20.
+    sbt_script=${sbt_script// /%20}
+    addJava "-Dsbt.script=$sbt_script"
+  fi
+}
+
+require_arg () {
+  local type="$1"
+  local opt="$2"
+  local arg="$3"
+  if [[ -z "$arg" ]] || [[ "${arg:0:1}" == "-" ]]; then
+    echo "$opt requires <$type> argument"
+    exit 1
+  fi
+}
+
+is_function_defined() {
+  declare -f "$1" > /dev/null
+}
+
+# parses JDK version from the -version output line.
+# 8 for 1.8.0_nn, 9 for 9-ea etc, and "no_java" for undetected
+jdk_version() {
+  local result
+  local lines=$("$java_cmd" -Xms32M -Xmx32M -version 2>&1 | tr '\r' '\n')
+  local IFS=$'\n'
+  for line in $lines; do
+    if [[ (-z $result) && ($line = *"version \""*) ]]
+    then
+      local ver=$(echo $line | sed -e 's/.*version "\(.*\)"\(.*\)/\1/; 1q')
+      # on macOS sed doesn't support '?'
+      if [[ $ver = "1."* ]]
+      then
+        result=$(echo $ver | sed -e 's/1\.\([0-9]*\)\(.*\)/\1/; 1q')
+      else
+        result=$(echo $ver | sed -e 's/\([0-9]*\)\(.*\)/\1/; 1q')
+      fi
+    fi
+  done
+  if [[ -z $result ]]
+  then
+    result=no_java
+  fi
+  echo "$result"
+}
+
+# Find the first occurrence of the given property name and returns its value by looking at:
+#   - properties set by command-line options,
+#   - JAVA_OPTS environment variable,
+#   - SBT_OPTS environment variable,
+#   - _JAVA_OPTIONS environment variable and
+#   - JAVA_TOOL_OPTIONS environment variable
+# in that order.
+findProperty() {
+  local -a java_opts_array
+  local -a sbt_opts_array
+  local -a _java_options_array
+  local -a java_tool_options_array
+  read -a java_opts_array <<< "$JAVA_OPTS"
+  read -a sbt_opts_array <<< "$SBT_OPTS"
+  read -a _java_options_array <<< "$_JAVA_OPTIONS"
+  read -a java_tool_options_array <<< "$JAVA_TOOL_OPTIONS"
+
+  local args_to_check=(
+    "${java_args[@]}"
+    "${java_opts_array[@]}"
+    "${sbt_opts_array[@]}"
+    "${_java_options_array[@]}"
+    "${java_tool_options_array[@]}")
+
+  for opt in "${args_to_check[@]}"; do
+    if [[ "$opt" == -D$1=* ]]; then
+      echo "${opt#-D$1=}"
+      return
+    fi
+  done
+}
+
+# Extracts the preloaded directory from either -Dsbt.preloaded, -Dsbt.global.base or -Duser.home
+# in that order.
+getPreloaded() {
+  local preloaded && preloaded=$(findProperty sbt.preloaded)
+  [ "$preloaded" ] && echo "$preloaded" && return
+
+  local global_base && global_base=$(findProperty sbt.global.base)
+  [ "$global_base" ] && echo "$global_base/preloaded" && return
+
+  local user_home && user_home=$(findProperty user.home)
+  echo "${user_home:-$HOME}/.sbt/preloaded"
+}
+
+syncPreloaded() {
+  local source_preloaded="$sbt_home/lib/local-preloaded/"
+  local target_preloaded="$(getPreloaded)"
+  if [[ "$init_sbt_version" == "" ]]; then
+    # FIXME: better $init_sbt_version detection
+    init_sbt_version="$(ls -1 "$source_preloaded/org/scala-sbt/sbt/")"
+  fi
+  [[ -f "$target_preloaded/org/scala-sbt/sbt/$init_sbt_version/" ]] || {
+    # lib/local-preloaded exists (This is optional)
+    [[ -d "$source_preloaded" ]] && {
+      command -v rsync >/dev/null 2>&1 && {
+        mkdir -p "$target_preloaded"
+        rsync --recursive --links --perms --times --ignore-existing "$source_preloaded" "$target_preloaded" || true
+      }
+    }
   }
 }
 
-usage () {
-  set_sbt_version
-  cat <<EOM
-Usage: $script_name [options]
+# Detect that we have java installed.
+checkJava() {
+  local required_version="$1"
+  # Now check to see if it's a good enough version
+  local good_enough="$(expr $java_version ">=" $required_version)"
+  if [[ "$java_version" == "" ]]; then
+    echo
+    echo "No Java Development Kit (JDK) installation was detected."
+    echo Please go to http://www.oracle.com/technetwork/java/javase/downloads/ and download.
+    echo
+    exit 1
+  elif [[ "$good_enough" != "1" ]]; then
+    echo
+    echo "The Java Development Kit (JDK) installation you have is not up to date."
+    echo $script_name requires at least version $required_version+, you have
+    echo version $java_version
+    echo
+    echo Please go to http://www.oracle.com/technetwork/java/javase/downloads/ and download
+    echo a valid JDK and install before running $script_name.
+    echo
+    exit 1
+  fi
+}
 
-Note that options which are passed along to sbt begin with -- whereas
-options to this runner use a single dash. Any sbt command can be scheduled
-to run first by prefixing the command with --, so --warn, --error and so on
-are not special.
+copyRt() {
+  local at_least_9="$(expr $java_version ">=" 9)"
+  if [[ "$at_least_9" == "1" ]]; then
+    # The grep for java9-rt-ext- matches the filename prefix printed in Export.java
+    java9_ext=$("$java_cmd" "${sbt_options[@]}" "${java_args[@]}" \
+      -jar "$sbt_jar" --rt-ext-dir | grep java9-rt-ext- | tr -d '\r')
+    java9_rt=$(echo "$java9_ext/rt.jar")
+    vlog "[copyRt] java9_rt = '$java9_rt'"
+    if [[ ! -f "$java9_rt" ]]; then
+      echo copying runtime jar...
+      mkdir -p "$java9_ext"
+      "$java_cmd" \
+        "${sbt_options[@]}" \
+        "${java_args[@]}" \
+        -jar "$sbt_jar" \
+        --export-rt \
+        "${java9_rt}"
+    fi
+    addJava "-Dscala.ext.dirs=${java9_ext}"
+  fi
+}
 
-Output filtering: if there is a file in the home directory called .sbtignore
-and this is not an interactive sbt session, the file is treated as a list of
-bash regular expressions. Output lines which match any regex are not echoed.
-One can see exactly which lines would have been suppressed by starting this
-runner with the -x option.
+# Confirm a user's intent if the current directory does not look like an sbt
+# top-level directory and neither the --allow-empty option nor the "new" command was given.
+checkWorkingDirectory() {
+  if [[ ! -n "$allow_empty" ]]; then
+    [[ -f ./build.sbt || -d ./project || -n "$sbt_new" ]] || {
+      echoerr_error "Neither build.sbt nor a 'project' directory in the current directory: $(pwd)"
+      echoerr_error "run 'sbt new', touch build.sbt, or run 'sbt --allow-empty'."
+      echoerr_error ""
+      echoerr_error "To opt out of this check, create ${config_home}/sbtopts with:"
+      echoerr_error "--allow-empty"
+      exit 1
+    }
+  fi
+}
 
-  -h | -help         print this message
-  -v                 verbose operation (this runner is chattier)
-  -d, -w, -q         aliases for --debug, --warn, --error (q means quiet)
-  -x                 debug this script
-  -trace <level>     display stack traces with a max of <level> frames (default: -1, traces suppressed)
-  -debug-inc         enable debugging log for the incremental compiler
-  -no-colors         disable ANSI color codes
-  -sbt-create        start sbt even if current directory contains no sbt project
-  -sbt-dir   <path>  path to global settings/plugins directory (default: ~/.sbt/<version>)
-  -sbt-boot  <path>  path to shared boot directory (default: ~/.sbt/boot in 0.11+)
-  -ivy       <path>  path to local Ivy repository (default: ~/.ivy2)
-  -no-share          use all local caches; no sharing
-  -offline           put sbt in offline mode
-  -jvm-debug <port>  Turn on JVM debugging, open at the given port.
-  -batch             Disable interactive mode
-  -prompt <expr>     Set the sbt prompt; in expr, 's' is the State and 'e' is Extracted
-  -script <file>     Run the specified file as a scala script
+run() {
+  # Copy preloaded repo to user's preloaded directory
+  syncPreloaded
 
-  # sbt version (default: sbt.version from $buildProps if present, otherwise $sbt_release_version)
-  -sbt-force-latest         force the use of the latest release of sbt: $sbt_release_version
-  -sbt-version  <version>   use the specified version of sbt (default: $sbt_release_version)
-  -sbt-dev                  use the latest pre-release version of sbt: $sbt_unreleased_version
-  -sbt-jar      <path>      use the specified jar as the sbt launcher
-  -sbt-launch-dir <path>    directory to hold sbt launchers (default: $sbt_launch_dir)
-  -sbt-launch-repo <url>    repo url for downloading sbt launcher jar (default: $(url_base "$sbt_version"))
+  # no jar? download it.
+  [[ -f "$sbt_jar" ]] || acquire_sbt_jar "$sbt_version" || {
+    exit 1
+  }
 
-  # scala version (default: as chosen by sbt)
-  -28                       use $latest_28
-  -29                       use $latest_29
-  -210                      use $latest_210
-  -211                      use $latest_211
-  -212                      use $latest_212
-  -213                      use $latest_213
-  -scala-home <path>        use the scala build at the specified directory
-  -scala-version <version>  use the specified version of scala
-  -binary-version <version> use the specified scala version when searching for dependencies
+  # TODO - java check should be configurable...
+  checkJava "8"
 
-  # java version (default: java from PATH, currently $(java -version 2>&1 | grep version))
-  -java-home <path>         alternate JAVA_HOME
+  # Java 9 support
+  copyRt
 
-  # passing options to the jvm - note it does NOT use JAVA_OPTS due to pollution
-  # The default set is used if JVM_OPTS is unset and no -jvm-opts file is found
-  <default>        $(default_jvm_opts)
-  JVM_OPTS         environment variable holding either the jvm args directly, or
-                   the reference to a file containing jvm args if given path is prepended by '@' (e.g. '@/etc/jvmopts')
-                   Note: "@"-file is overridden by local '.jvmopts' or '-jvm-opts' argument.
-  -jvm-opts <path> file containing jvm args (if not given, .jvmopts in project root is used if present)
-  -Dkey=val        pass -Dkey=val directly to the jvm
-  -J-X             pass option -X directly to the jvm (-J is stripped)
+  # If we're in cygwin, we should use the windows config, and terminal hacks
+  if [[ "$CYGWIN_FLAG" == "true" ]]; then #"
+    stty -icanon min 1 -echo > /dev/null 2>&1
+    addJava "-Djline.terminal=jline.UnixTerminal"
+    addJava "-Dsbt.cygwin=true"
+  fi
 
-  # passing options to sbt, OR to this runner
-  SBT_OPTS         environment variable holding either the sbt args directly, or
-                   the reference to a file containing sbt args if given path is prepended by '@' (e.g. '@/etc/sbtopts')
-                   Note: "@"-file is overridden by local '.sbtopts' or '-sbt-opts' argument.
-  -sbt-opts <path> file containing sbt args (if not given, .sbtopts in project root is used if present)
-  -S-X             add -X to sbt's scalacOptions (-S is stripped)
+  if [[ $print_sbt_version ]]; then
+    execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]//g'
+  elif [[ $print_sbt_script_version ]]; then
+    echo "$init_sbt_version"
+  elif [[ $print_version ]]; then
+    execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]/sbt version in this project:/g'
+    echo "sbt script version: $init_sbt_version"
+  elif [[ $shutdownall ]]; then
+    local sbt_processes=( $(jps -v | grep sbt-launch | cut -f1 -d ' ') )
+    for procId in "${sbt_processes[@]}"; do
+      kill -9 $procId
+    done
+    echo "shutdown ${#sbt_processes[@]} sbt processes"
+  else
+    checkWorkingDirectory
+    # run sbt
+    execRunner "$java_cmd" \
+      "${java_args[@]}" \
+      "${sbt_options[@]}" \
+      "${java_tool_options[@]}" \
+      -jar "$sbt_jar" \
+      "${sbt_commands[@]}" \
+      "${residual_args[@]}"
+  fi
+
+  exit_code=$?
+
+  # Clean up the terminal from cygwin hacks.
+  if [[ "$CYGWIN_FLAG" == "true" ]]; then #"
+    stty icanon echo > /dev/null 2>&1
+  fi
+  exit $exit_code
+}
+
+declare -ra noshare_opts=(-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy)
+declare -r sbt_opts_file=".sbtopts"
+declare -r build_props_file="$(pwd)/project/build.properties"
+declare -r etc_sbt_opts_file="/etc/sbt/sbtopts"
+# this allows /etc/sbt/sbtopts location to be changed
+declare machine_sbt_opts_file="${etc_sbt_opts_file}"
+declare config_home="${XDG_CONFIG_HOME:-$HOME/.config}/sbt"
+[[ -f "${config_home}/sbtopts" ]] && machine_sbt_opts_file="${config_home}/sbtopts"
+[[ -f "$SBT_ETC_FILE" ]] && machine_sbt_opts_file="$SBT_ETC_FILE"
+declare -r dist_sbt_opts_file="${sbt_home}/conf/sbtopts"
+declare -r win_sbt_opts_file="${sbt_home}/conf/sbtconfig.txt"
+declare sbt_jar="$(jar_file)"
+
+usage() {
+ cat <<EOM
+Usage: `basename "$0"` [options]
+
+  -h | --help         print this message
+  -v | --verbose      this runner is chattier
+  -V | --version      print sbt version information
+  --numeric-version   print the numeric sbt version (sbt sbtVersion)
+  --script-version    print the version of sbt script
+  shutdownall         shutdown all running sbt-launch processes
+  -d | --debug        set sbt log level to debug
+  -debug-inc | --debug-inc
+                      enable extra debugging for the incremental debugger
+  --no-colors         disable ANSI color codes
+  --color=auto|always|true|false|never
+                      enable or disable ANSI color codes      (sbt 1.3 and above)
+  --supershell=auto|always|true|false|never
+                      enable or disable supershell            (sbt 1.3 and above)
+  --traces            generate Trace Event report on shutdown (sbt 1.3 and above)
+  --timings           display task timings report on shutdown
+  --allow-empty       start sbt even if current directory contains no sbt project
+  --sbt-dir   <path>  path to global settings/plugins directory (default: ~/.sbt)
+  --sbt-boot  <path>  path to shared boot directory (default: ~/.sbt/boot in 0.11 series)
+  --sbt-cache <path>  path to global cache directory (default: operating system specific)
+  --ivy       <path>  path to local Ivy repository (default: ~/.ivy2)
+  --mem    <integer>  set memory options (default: $sbt_default_mem)
+  --no-share          use all local caches; no sharing
+  --no-global         uses global caches, but does not use global ~/.sbt directory.
+  --jvm-debug <port>  Turn on JVM debugging, open at the given port.
+  --batch             disable interactive mode
+
+  # sbt version (default: from project/build.properties if present, else latest release)
+  --sbt-version  <version>   use the specified version of sbt
+  --sbt-jar      <path>      use the specified jar as the sbt launcher
+
+  --java-home <path>         alternate JAVA_HOME
+
+  # jvm options and output control
+  JAVA_OPTS           environment variable, if unset uses "$default_java_opts"
+  .jvmopts            if this file exists in the current directory, its contents
+                      are appended to JAVA_OPTS
+  SBT_OPTS            environment variable, if unset uses "$default_sbt_opts"
+  .sbtopts            if this file exists in the current directory, its contents
+                      are prepended to the runner args
+  /etc/sbt/sbtopts    if this file exists, it is prepended to the runner args
+  -Dkey=val           pass -Dkey=val directly to the java runtime
+  -J-X                pass option -X directly to the java runtime
+                      (-J is stripped)
+
+In the case of duplicated or conflicting options, the order above
+shows precedence: JAVA_OPTS lowest, command line options highest.
 EOM
+}
+
+process_my_args () {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+             -batch|--batch) exec </dev/null && shift ;; #>
+
+   -allow-empty|--allow-empty|-sbt-create|--sbt-create) allow_empty=true && shift ;;
+
+                        new) sbt_new=true && addResidual "$1" && shift ;;
+
+                          *) addResidual "$1" && shift ;;
+    esac
+  done
+
+  # Now, ensure sbt version is used.
+  [[ "${sbt_version}XXX" != "XXX" ]] && addJava "-Dsbt.version=$sbt_version"
+}
+
+## map over argument array. this is used to process both command line arguments and SBT_OPTS
+map_args () {
+  local options=()
+  local commands=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+     -no-colors|--no-colors) options=( "${options[@]}" "-Dsbt.log.noformat=true" ) && shift ;;
+         -timings|--timings) options=( "${options[@]}" "-Dsbt.task.timings=true" "-Dsbt.task.timings.on.shutdown=true" ) && shift ;;
+           -traces|--traces) options=( "${options[@]}" "-Dsbt.traces=true" ) && shift ;;
+             --supershell=*) options=( "${options[@]}" "-Dsbt.supershell=${1:13}" ) && shift ;;
+              -supershell=*) options=( "${options[@]}" "-Dsbt.supershell=${1:12}" ) && shift ;;
+     -no-server|--no-server) options=( "${options[@]}" "-Dsbt.io.virtual=false" "-Dsbt.server.autostart=false" ) && shift ;;
+                  --color=*) options=( "${options[@]}" "-Dsbt.color=${1:8}" ) && shift ;;
+                   -color=*) options=( "${options[@]}" "-Dsbt.color=${1:7}" ) && shift ;;
+       -no-share|--no-share) options=( "${options[@]}" "${noshare_opts[@]}" ) && shift ;;
+     -no-global|--no-global) options=( "${options[@]}" "-Dsbt.global.base=$(pwd)/project/.sbtboot" ) && shift ;;
+                 -ivy|--ivy) require_arg path "$1" "$2" && options=( "${options[@]}" "-Dsbt.ivy.home=$2" ) && shift 2 ;;
+       -sbt-boot|--sbt-boot) require_arg path "$1" "$2" && options=( "${options[@]}" "-Dsbt.boot.directory=$2" ) && shift 2 ;;
+         -sbt-dir|--sbt-dir) require_arg path "$1" "$2" && options=( "${options[@]}" "-Dsbt.global.base=$2" ) && shift 2 ;;
+             -debug|--debug) commands=( "${commands[@]}" "-debug" ) && shift ;;
+     -debug-inc|--debug-inc) options=( "${options[@]}" "-Dxsbt.inc.debug=true" ) && shift ;;
+                          *) options=( "${options[@]}" "$1" ) && shift ;;
+    esac
+  done
+  declare -p options
+  declare -p commands
 }
 
 process_args () {
-  require_arg () {
-    local type="$1"
-    local opt="$2"
-    local arg="$3"
-
-    if [[ -z "$arg" ]] || [[ "${arg:0:1}" == "-" ]]; then
-      die "$opt requires <$type> argument"
-    fi
-  }
   while [[ $# -gt 0 ]]; do
     case "$1" in
-          -h|-help) usage; exit 0 ;;
-                -v) verbose=true && shift ;;
-                -d) addSbt "--debug" && shift ;;
-                -w) addSbt "--warn"  && shift ;;
-                -q) addSbt "--error" && shift ;;
-                -x) debugUs=true && shift ;;
-            -trace) require_arg integer "$1" "$2" && trace_level="$2" && shift 2 ;;
-              -ivy) require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;
-        -no-colors) addJava "-Dsbt.log.noformat=true" && shift ;;
-         -no-share) noshare=true && shift ;;
-         -sbt-boot) require_arg path "$1" "$2" && addJava "-Dsbt.boot.directory=$2" && shift 2 ;;
-          -sbt-dir) require_arg path "$1" "$2" && sbt_dir="$2" && shift 2 ;;
-        -debug-inc) addJava "-Dxsbt.inc.debug=true" && shift ;;
-          -offline) addSbt "set offline in Global := true" && shift ;;
-        -jvm-debug) require_arg port "$1" "$2" && addDebugger "$2" && shift 2 ;;
-            -batch) batch=true && shift ;;
-           -prompt) require_arg "expr" "$1" "$2" && setThisBuild shellPrompt "(s => { val e = Project.extract(s) ; $2 })" && shift 2 ;;
-           -script) require_arg file "$1" "$2" && sbt_script="$2" && addJava "-Dsbt.main.class=sbt.ScriptMain" && shift 2 ;;
+            -h|-help|--help) usage; exit 1 ;;
+      -v|-verbose|--verbose) sbt_verbose=1 && shift ;;
+      -V|-version|--version) print_version=1 && shift ;;
+          --numeric-version) print_sbt_version=1 && shift ;;
+           --script-version) print_sbt_script_version=1 && shift ;;
+                shutdownall) shutdownall=1 && shift ;;
+          -d|-debug|--debug) sbt_debug=1 && addSbt "-debug" && shift ;;
+           -client|--client) use_sbtn=1 && shift ;;
+                   --server) use_sbtn=0 && shift ;;
 
-       -sbt-create) sbt_create=true && shift ;;
-          -sbt-jar) require_arg path "$1" "$2" && sbt_jar="$2" && shift 2 ;;
-      -sbt-version) require_arg version "$1" "$2" && sbt_explicit_version="$2" && shift 2 ;;
- -sbt-force-latest) sbt_explicit_version="$sbt_release_version" && shift ;;
-          -sbt-dev) sbt_explicit_version="$sbt_unreleased_version" && shift ;;
-   -sbt-launch-dir) require_arg path "$1" "$2" && sbt_launch_dir="$2" && shift 2 ;;
-  -sbt-launch-repo) require_arg path "$1" "$2" && sbt_launch_repo="$2" && shift 2 ;;
-    -scala-version) require_arg version "$1" "$2" && setScalaVersion "$2" && shift 2 ;;
-   -binary-version) require_arg version "$1" "$2" && setThisBuild scalaBinaryVersion "\"$2\"" && shift 2 ;;
-       -scala-home) require_arg path "$1" "$2" && setThisBuild scalaHome "_root_.scala.Some(file(\"$2\"))" && shift 2 ;;
-        -java-home) require_arg path "$1" "$2" && setJavaHome "$2" && shift 2 ;;
-         -sbt-opts) require_arg path "$1" "$2" && sbt_opts_file="$2" && shift 2 ;;
-         -jvm-opts) require_arg path "$1" "$2" && jvm_opts_file="$2" && shift 2 ;;
+                 -mem|--mem) require_arg integer "$1" "$2" && addMemory "$2" && shift 2 ;;
+     -jvm-debug|--jvm-debug) require_arg port "$1" "$2" && addDebugger $2 && shift 2 ;;
+             -batch|--batch) exec </dev/null && shift ;;
 
-               -D*) addJava "$1" && shift ;;
-               -J*) addJava "${1:2}" && shift ;;
-               -S*) addScalac "${1:2}" && shift ;;
-               -28) setScalaVersion "$latest_28" && shift ;;
-               -29) setScalaVersion "$latest_29" && shift ;;
-              -210) setScalaVersion "$latest_210" && shift ;;
-              -211) setScalaVersion "$latest_211" && shift ;;
-              -212) setScalaVersion "$latest_212" && shift ;;
-              -213) setScalaVersion "$latest_213" && shift ;;
-               new) sbt_new=true && : ${sbt_explicit_version:=$sbt_release_version} && addResidual "$1" && shift ;;
-                 *) addResidual "$1" && shift ;;
+         -sbt-jar|--sbt-jar) require_arg path "$1" "$2" && sbt_jar="$2" && shift 2 ;;
+     -sbt-cache|--sbt-cache) require_arg path "$1" "$2" &&
+                             sbt_cache="$2" &&
+                             addJava "-Dsbt.global.localcache=$2" &&
+                             shift 2 ;;
+ -sbt-version|--sbt-version) require_arg version "$1" "$2" && sbt_version="$2" && shift 2 ;;
+     -java-home|--java-home) require_arg path "$1" "$2" &&
+                             java_cmd="$2/bin/java" &&
+                             export JAVA_HOME="$2" &&
+                             export JDK_HOME="$2" &&
+                             export PATH="$2/bin:$PATH" &&
+                             shift 2 ;;
+
+ -Dsbt.color=never|-Dsbt.log.noformat=true) addJava "$1" && use_colors=0 && shift ;;
+                  "-D*"|-D*) addJava "$1" && shift ;;
+                        -J*) addJava "${1:2}" && shift ;;
+                          *) addResidual "$1" && shift ;;
     esac
   done
-}
 
-# process the direct command line arguments
-process_args "$@"
-
-# skip #-styled comments and blank lines
-readConfigFile() {
-  local end=false
-  until $end; do
-    read || end=true
-    [[ $REPLY =~ ^# ]] || [[ -z $REPLY ]] || echo "$REPLY"
-  done < "$1"
-}
-
-# if there are file/environment sbt_opts, process again so we
-# can supply args to this runner
-if [[ -r "$sbt_opts_file" ]]; then
-  vlog "Using sbt options defined in file $sbt_opts_file"
-  while read opt; do extra_sbt_opts+=("$opt"); done < <(readConfigFile "$sbt_opts_file")
-elif [[ -n "$SBT_OPTS" && ! ("$SBT_OPTS" =~ ^@.*) ]]; then
-  vlog "Using sbt options defined in variable \$SBT_OPTS"
-  extra_sbt_opts=( $SBT_OPTS )
-else
-  vlog "No extra sbt options have been defined"
-fi
-
-[[ -n "${extra_sbt_opts[*]}" ]] && process_args "${extra_sbt_opts[@]}"
-
-# reset "$@" to the residual args
-set -- "${residual_args[@]}"
-argumentCount=$#
-
-# set sbt version
-set_sbt_version
-
-checkJava
-
-# only exists in 0.12+
-setTraceLevel() {
-  case "$sbt_version" in
-    "0.7."* | "0.10."* | "0.11."* ) echoerr "Cannot set trace level in sbt version $sbt_version" ;;
-                                 *) setThisBuild traceLevel $trace_level ;;
-  esac
-}
-
-# set scalacOptions if we were given any -S opts
-[[ ${#scalac_args[@]} -eq 0 ]] || addSbt "set scalacOptions in ThisBuild += \"${scalac_args[@]}\""
-
-# Update build.properties on disk to set explicit version - sbt gives us no choice
-[[ -n "$sbt_explicit_version" && -z "$sbt_new" ]] && update_build_props_sbt "$sbt_explicit_version"
-vlog "Detected sbt version $sbt_version"
-
-if [[ -n "$sbt_script" ]]; then
-  residual_args=( $sbt_script ${residual_args[@]} )
-else
-  # no args - alert them there's stuff in here
-  (( argumentCount > 0 )) || {
-    vlog "Starting $script_name: invoke with -help for other options"
-    residual_args=( shell )
+  is_function_defined process_my_args && {
+    myargs=("${residual_args[@]}")
+    residual_args=()
+    process_my_args "${myargs[@]}"
   }
-fi
-
-# verify this is an sbt dir, -create was given or user attempts to run a scala script
-[[ -r ./build.sbt || -d ./project || -n "$sbt_create" || -n "$sbt_script" || -n "$sbt_new" ]] || {
-  cat <<EOM
-$(pwd) doesn't appear to be an sbt project.
-If you want to start sbt anyway, run:
-  $0 -sbt-create
-
-EOM
-  exit 1
 }
 
-# pick up completion if present; todo
-[[ -r .sbt_completion.sh ]] && source .sbt_completion.sh
-
-# directory to store sbt launchers
-[[ -d "$sbt_launch_dir" ]] || mkdir -p "$sbt_launch_dir"
-[[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$(mktemp -d -t sbt_extras_launchers.XXXXXX)"
-
-# no jar? download it.
-[[ -r "$sbt_jar" ]] || acquire_sbt_jar || {
-  # still no jar? uh-oh.
-  echo "Download failed. Obtain the jar manually and place it at $sbt_jar"
-  exit 1
-}
-
-if [[ -n "$noshare" ]]; then
-  for opt in ${noshare_opts}; do
-    addJava "$opt"
+loadConfigFile() {
+  # Make sure the last line is read even if it doesn't have a terminating \n
+  cat "$1" | sed $'/^\#/d;s/\r$//' | while read -r line || [[ -n "$line" ]]; do
+    eval echo $line
   done
-else
-  case "$sbt_version" in
-    "0.7."* | "0.10."* | "0.11."* | "0.12."* )
-      [[ -n "$sbt_dir" ]] || {
-        sbt_dir="$HOME/.sbt/$sbt_version"
-        vlog "Using $sbt_dir as sbt dir, -sbt-dir to override."
-      }
-    ;;
-  esac
-
-  if [[ -n "$sbt_dir" ]]; then
-    addJava "-Dsbt.global.base=$sbt_dir"
-  fi
-fi
-
-if [[ -r "$jvm_opts_file" ]]; then
-  vlog "Using jvm options defined in file $jvm_opts_file"
-  while read opt; do extra_jvm_opts+=("$opt"); done < <(readConfigFile "$jvm_opts_file")
-elif [[ -n "$JVM_OPTS" && ! ("$JVM_OPTS" =~ ^@.*) ]]; then
-  vlog "Using jvm options defined in \$JVM_OPTS variable"
-  extra_jvm_opts=( $JVM_OPTS )
-else
-  vlog "Using default jvm options"
-  extra_jvm_opts=( $(default_jvm_opts) )
-fi
-
-# traceLevel is 0.12+
-[[ -n "$trace_level" ]] && setTraceLevel
-
-main () {
-  execRunner "$java_cmd" \
-    "${extra_jvm_opts[@]}" \
-    "${java_args[@]}" \
-    -jar "$sbt_jar" \
-    "${sbt_commands[@]}" \
-    "${residual_args[@]}"
 }
 
-# sbt inserts this string on certain lines when formatting is enabled:
-#   val OverwriteLine = "\r\u001BM\u001B[2K"
-# ...in order not to spam the console with a million "Resolving" lines.
-# Unfortunately that makes it that much harder to work with when
-# we're not going to print those lines anyway. We strip that bit of
-# line noise, but leave the other codes to preserve color.
-mainFiltered () {
-  local ansiOverwrite='\r\x1BM\x1B[2K'
-  local excludeRegex=$(egrep -v '^#|^$' ~/.sbtignore | paste -sd'|' -)
-
-  echoLine () {
-    local line="$1"
-    local line1="$(echo "$line" | sed 's/\r\x1BM\x1B\[2K//g')"       # This strips the OverwriteLine code.
-    local line2="$(echo "$line1" | sed 's/\x1B\[[0-9;]*[JKmsu]//g')" # This strips all codes - we test regexes against this.
-
-    if [[ $line2 =~ $excludeRegex ]]; then
-      [[ -n $debugUs ]] && echo "[X] $line1"
-    else
-      [[ -n $debugUs ]] && echo "    $line1" || echo "$line1"
+loadPropFile() {
+  # trim key and value so as to be more forgiving with spaces around the '=':
+  k=$(trimString $k)
+  v=$(trimString $v)
+  while IFS='=' read -r k v; do
+    if [[ "$k" == "sbt.version" ]]; then
+      build_props_sbt_version="$v"
     fi
-  }
-
-  echoLine "Starting sbt with output filtering enabled."
-  main | while read -r line; do echoLine "$line"; done
+  done <<< "$(cat "$1" | sed $'/^\#/d;s/\r$//')"
 }
 
-# Only filter if there's a filter file and we don't see a known interactive command.
-# Obviously this is super ad hoc but I don't know how to improve on it. Testing whether
-# stdin is a terminal is useless because most of my use cases for this filtering are
-# exactly when I'm at a terminal, running sbt non-interactively.
-shouldFilter () { [[ -f ~/.sbtignore ]] && ! egrep -q '\b(shell|console|consoleProject)\b' <<<"${residual_args[@]}"; }
+detectNativeClient() {
+  if [[ "$sbtn_command" != "" ]]; then
+    :
+  elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    arch=$(uname -m)
+    [[ -f "${sbt_bin_dir}/sbtn-${arch}-pc-linux" ]] && sbtn_command="${sbt_bin_dir}/sbtn-${arch}-pc-linux"
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    [[ -f "${sbt_bin_dir}/sbtn-x86_64-apple-darwin" ]] && sbtn_command="${sbt_bin_dir}/sbtn-x86_64-apple-darwin"
+  elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
+    [[ -f "${sbt_bin_dir}/sbtn-x86_64-pc-win32.exe" ]] && sbtn_command="${sbt_bin_dir}/sbtn-x86_64-pc-win32.exe"
+  elif [[ "$OSTYPE" == "freebsd"* ]]; then
+    :
+  else
+    :
+  fi
+}
 
-# run sbt
-if shouldFilter; then mainFiltered; else main; fi
+# Run native client if build.properties points to 1.4+ and has SBT_NATIVE_CLIENT
+isRunNativeClient() {
+  sbtV="$build_props_sbt_version"
+  [[ "$sbtV" == "" ]] && sbtV="$init_sbt_version"
+  [[ "$sbtV" == "" ]] && sbtV="0.0.0"
+  sbtBinaryV_1=$(echo "$sbtV" | sed 's/^\([0-9]*\)\.\([0-9]*\).*$/\1/')
+  sbtBinaryV_2=$(echo "$sbtV" | sed 's/^\([0-9]*\)\.\([0-9]*\).*$/\2/')
+  # Default to true for sbt 2.x
+  if (( $sbtBinaryV_1 >= 2 )); then
+    if [[ "$use_sbtn" == "0" ]]; then
+      echo "false"
+    else
+      echo "true"
+    fi
+  elif ( (( $sbtBinaryV_1 >= 1 )) && (( $sbtBinaryV_2 >= 4 )) ); then
+    if [[ "$use_sbtn" == "1" ]]; then
+      echo "true"
+    else
+      echo "false"
+    fi
+  else
+    echo "false"
+  fi
+}
+
+runNativeClient() {
+  vlog "[debug] running native client"
+  detectNativeClient
+  [[ -f "$sbtn_command" ]] || acquire_sbtn "$sbtn_version" || {
+    exit 1
+  }
+  for i in "${!original_args[@]}"; do
+    if [[ "${original_args[i]}" = "--client" ]]; then
+      unset 'original_args[i]'
+    fi
+  done
+  sbt_script=$0
+  sbt_script=${sbt_script/ /%20}
+  execRunner "$sbtn_command" "--sbt-script=$sbt_script" "${original_args[@]}"
+}
+
+original_args=("$@")
+
+# Pull in the machine-wide settings configuration.
+if [[ -f "$machine_sbt_opts_file" ]]; then
+  set -- $(loadConfigFile "$machine_sbt_opts_file") "$@"
+else
+  # Otherwise pull in the default settings configuration.
+  [[ -f "$dist_sbt_opts_file" ]] && set -- $(loadConfigFile "$dist_sbt_opts_file") "$@"
+fi
+
+# Pull in the project-level config file, if it exists.
+[[ -f "$sbt_opts_file" ]] && set -- $(loadConfigFile "$sbt_opts_file") "$@"
+
+# Pull in the project-level java config, if it exists.
+[[ -f ".jvmopts" ]] && export JAVA_OPTS="$JAVA_OPTS $(loadConfigFile .jvmopts)"
+
+# Pull in default JAVA_OPTS
+[[ -z "${JAVA_OPTS// }" ]] && export JAVA_OPTS="$default_java_opts"
+
+[[ -f "$build_props_file" ]] && loadPropFile "$build_props_file"
+
+java_args=($JAVA_OPTS)
+sbt_options0=(${SBT_OPTS:-$default_sbt_opts})
+java_tool_options=($JAVA_TOOL_OPTIONS)
+if [[ "$SBT_NATIVE_CLIENT" == "true" ]]; then
+  use_sbtn=1
+fi
+
+# Split SBT_OPTS into options/commands
+miniscript=$(map_args "${sbt_options0[@]}") && eval "${miniscript/options/sbt_options}" && \
+eval "${miniscript/commands/sbt_additional_commands}"
+
+# Combine command line options/commands and commands from SBT_OPTS
+miniscript=$(map_args "$@") && eval "${miniscript/options/cli_options}" && eval "${miniscript/commands/cli_commands}"
+args1=( "${cli_options[@]}" "${cli_commands[@]}" "${sbt_additional_commands[@]}" )
+
+# process the combined args, then reset "$@" to the residuals
+process_args "${args1[@]}"
+vlog "[sbt_options] $(declare -p sbt_options)"
+
+if [[ "$(isRunNativeClient)" == "true" ]]; then
+  set -- "${residual_args[@]}"
+  argumentCount=$#
+  runNativeClient
+else
+  java_version="$(jdk_version)"
+  vlog "[process_args] java_version = '$java_version'"
+  addDefaultMemory
+  addSbtScriptProperty
+  set -- "${residual_args[@]}"
+  argumentCount=$#
+  run
+fi


### PR DESCRIPTION
The bundled `sbt` script is outdated, for example, it can not process java_version correctly.
```
$ ./sbt compile
./sbt: line 204: [[: .: syntax error: operand expected (error token is ".")
Unrecognized VM option 'MaxPermSize=384m'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

This PR Bump SBT 1.10.7 and sync the `sbt` script from https://github.com/sbt/sbt/blob/v1.10.7/sbt