### PR TITLE
Expose database, username, password args for ClickHouseContainer

### DIFF
--- a/modules/clickhouse/src/main/scala/com/dimafeng/testcontainers/ClickHouseContainer.scala
+++ b/modules/clickhouse/src/main/scala/com/dimafeng/testcontainers/ClickHouseContainer.scala
@@ -1,30 +1,49 @@
 package com.dimafeng.testcontainers
 
-import org.testcontainers.containers.{ClickHouseContainer => JavaClickHouseContainer}
+import org.testcontainers.clickhouse.{ClickHouseContainer => JavaClickHouseContainer}
 import org.testcontainers.utility.DockerImageName
 
 case class ClickHouseContainer(
-  dockerImageName: DockerImageName = DockerImageName.parse(ClickHouseContainer.defaultDockerImageName)
+  dockerImageName: DockerImageName = DockerImageName.parse(ClickHouseContainer.defaultDockerImageName),
+  clickhouseDatabaseName: Option[String] = None,
+  clickhouseUsername: Option[String] = None,
+  clickhousePassword: Option[String] = None
 ) extends SingleContainer[JavaClickHouseContainer] with JdbcDatabaseContainer {
 
-  override val container: JavaClickHouseContainer = new JavaClickHouseContainer(dockerImageName)
+  override val container: JavaClickHouseContainer = {
+    val c = new JavaClickHouseContainer(dockerImageName)
+    clickhouseDatabaseName.map(c.withDatabaseName)
+    clickhouseUsername.map(c.withUsername)
+    clickhousePassword.map(c.withPassword)
+    c
+  }
 
   def testQueryString: String = container.getTestQueryString
 }
 
 object ClickHouseContainer {
 
-  val defaultDockerImageName = s"${JavaClickHouseContainer.IMAGE}:${JavaClickHouseContainer.DEFAULT_TAG}"
+  // Copy String literal because JavaClickHouseContainer.CLICKHOUSE_IMAGE_NAME is private
+  val defaultDockerImageName = "clickhouse/clickhouse-server"
+  val defaultDatabaseName = "test"
+  val defaultUsername = "test"
+  val defaultPassword = "test"
 
   case class Def(
-    dockerImageName: DockerImageName = DockerImageName.parse(ClickHouseContainer.defaultDockerImageName)
+    dockerImageName: DockerImageName = DockerImageName.parse(defaultDockerImageName),
+    databaseName: String = defaultDatabaseName,
+    username: String = defaultUsername,
+    password: String = defaultPassword,
   ) extends ContainerDef {
 
     override type Container = ClickHouseContainer
 
     override def createContainer(): ClickHouseContainer = {
       new ClickHouseContainer(
-        dockerImageName = dockerImageName
+        dockerImageName = dockerImageName,
+        clickhouseDatabaseName = Some(databaseName),
+        clickhouseUsername = Some(username),
+        clickhousePassword = Some(password)
       )
     }
   }


### PR DESCRIPTION
The ClickHouseContainer stopped working recently due to the `default` user is not allowed to access from outside of the container without setting CLICKHOUSE_PASSWORD. See details at https://github.com/testcontainers/testcontainers-java/pull/9942

```
/entrypoint.sh: neither CLICKHOUSE_USER nor CLICKHOUSE_PASSWORD is set, disabling network access for user 'default'
```

Unfortunately, the Scala-wrapped ClickHouseContainer does not expose those args so nothing I can do to workaround the test failure in downstream projects.

Changes are verified locally by 

```
$ sbt moduleClickhouse/test
... 
[info] ClickHouseContainer
[info] - should work
[info] Run completed in 5 seconds, 563 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 8 s, completed Feb 14, 2025, 11:31:22 AM
```