### PR TITLE
Bump test containers to 1.20.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     scope.map(s => modules.map(_ % s)).getOrElse(modules)
   }
 
-  private val testcontainersVersion = "1.20.2"
+  private val testcontainersVersion = "1.20.6"
   private val seleniumVersion = "2.53.1"
   private val slf4jVersion = "1.7.32"
   private val scalaTestVersion = "3.2.9"


### PR DESCRIPTION
This is the same as #425 created by scala steward, but with the latest changes from `main` so hopefully the build passes